### PR TITLE
Point to conda-forge

### DIFF
--- a/doc/sphinx/source/installation.rst
+++ b/doc/sphinx/source/installation.rst
@@ -5,24 +5,30 @@ Installation
 =============
 
 
+Using CONDA
+-----------
+
+PyFMI is available through `conda <http://conda.pydata.org/docs/index.html>`_::
+
+    conda install -c conda-forge pyfmi
+    
+Using PIP
+---------
+
 Current version:
 
     Available on PyPI, http://pypi.python.org/pypi/PyFMI
 
-Additionally, PyFMI is available through `conda <http://conda.pydata.org/docs/index.html>`_::
-
-    conda install -c https://conda.binstar.org/chria pyfmi
-
 Requirements:
--------------
+^^^^^^^^^^^^^
 - `FMI Library <http://www.jmodelica.org/FMILibrary>`_
 - `Numpy <http://pypi.python.org/pypi/numpy>`_
 - `Scipy <http://pypi.python.org/pypi/scipy>`_
 - `lxml <http://pypi.python.org/pypi/lxml>`_
 - `Assimulo <http://pypi.python.org/pypi/Assimulo>`_
 
-Optional
----------
+Optional:
+^^^^^^^^^
 - `wxPython <http://pypi.python.org/pypi/wxPython>`_ For the Plot GUI.
 - `matplotlib <http://pypi.python.org/pypi/matplotlib>`_ For the Plot GUI.
 


### PR DESCRIPTION
Dear JModelica people,
I first try to install PyFMI using conda and following the instructions from
https://jmodelica.org/pyfmi/installation.html#
I run into the problem of the FMILibrarynot being installed but after a while understood that the new version is now hosted on conda-forge and not in https://conda.binstar.org/chria anymore.
Maybe this webpage could be updated to point to conda-forge.

Best regards,