### PR TITLE
Updates to deallocation of loaded FMUs

### DIFF
--- a/src/pyfmi/fmi.pxd
+++ b/src/pyfmi/fmi.pxd
@@ -169,7 +169,7 @@ cdef class FMUModelBase2(ModelBase):
     cdef public float  _last_accepted_time, _relative_tolerance
     cdef object         _fmu_full_path
     cdef public object  _enable_logging
-    cdef int _allocated_dll, _allocated_context, _allocated_xml, _allocated_fmu
+    cdef int _allocated_dll, _allocated_context, _allocated_xml, _allocated_fmu, _initialized_fmu
     cdef object         _modelId
     cdef object         _modelName
     cdef public list    _save_real_variables_val

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -6587,7 +6587,7 @@ cdef class FMUModelCS2(FMUModelBase2):
         """
         Deallocate memory allocated
         """
-        if self._intialized_fmu == 1:
+        if self._initialized_fmu == 1:
             FMIL.fmi2_import_terminate(self._fmu)
             
         if self._allocated_fmu == 1:

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -3733,6 +3733,7 @@ cdef class FMUModelBase2(ModelBase):
         self._allocated_dll = 0
         self._allocated_xml = 0
         self._allocated_fmu = 0
+        self._initialized_fmu = 0
         self._fmu_temp_dir = NULL
         self._fmu_log_name = NULL
 
@@ -4307,6 +4308,8 @@ cdef class FMUModelBase2(ModelBase):
 
         if status != FMIL.jm_status_success:
             raise FMUException('Failed to instantiate the model. See the log for possibly more information.')
+        
+        self._allocated_fmu = 1
     
     def setup_experiment(self, tolerance_defined=True, tolerance="Default", start_time="Default", stop_time_defined=False, stop_time="Default"):
         """
@@ -4375,7 +4378,7 @@ cdef class FMUModelBase2(ModelBase):
         self._has_entered_init_mode = False
         
         #Reseting the allocation flags
-        self._allocated_fmu = 0
+        self._initialized_fmu = 0
 
         #Internal values
         self._log = []
@@ -4423,7 +4426,7 @@ cdef class FMUModelBase2(ModelBase):
                     ' Enable logging for more information, (load_fmu(..., log_level=4)).')
                     
 
-        self._allocated_fmu = 1
+        self._initialized_fmu = 1
         
         return status
         
@@ -6584,8 +6587,10 @@ cdef class FMUModelCS2(FMUModelBase2):
         """
         Deallocate memory allocated
         """
-        if self._allocated_fmu == 1:
+        if self._intialized_fmu == 1:
             FMIL.fmi2_import_terminate(self._fmu)
+            
+        if self._allocated_fmu == 1:
             FMIL.fmi2_import_free_instance(self._fmu)
 
         if self._allocated_dll == 1:
@@ -7201,8 +7206,10 @@ cdef class FMUModelME2(FMUModelBase2):
         Deallocate memory allocated
         """
 
-        if self._allocated_fmu == 1:
+        if self._initialized_fmu == 1:
             FMIL.fmi2_import_terminate(self._fmu)
+        
+        if self._allocated_fmu == 1:
             FMIL.fmi2_import_free_instance(self._fmu)
 
         if self._allocated_dll == 1:


### PR DESCRIPTION
This PR resolves an issue with deallocating loaded FMUs. The issue could be observed by calling the function `load_fmu(...)` repeatedly. Earlier the attribute `_allocated_fmu` was only set to `1` if the FMU had been initialized, this behavior is incorrect since not everything that was allocated during `load_fmu(...)` would be deallocated due to the attribute `_allocated_fmu` only being set to `1` if the FMU was initialized.