### PR TITLE
Updated declaration of internal_state_variables

### DIFF
--- a/src/pyfmi/fmi.pxd
+++ b/src/pyfmi/fmi.pxd
@@ -92,7 +92,7 @@ cdef class FMUState2:
     Class containing a pointer to a FMU-state.
     """
     cdef FMIL.fmi2_FMU_state_t fmu_state
-    cdef dict _internal_state_variables
+    cdef object _internal_state_variables
 
 cdef class FMUModelBase(ModelBase):
     """


### PR DESCRIPTION
This update is due to the changes in https://github.com/modelon-community/PyFMI/pull/50
Since "cdef dict internal_state_variables" would cause a TypeError.

Perhaps there is a better type to declare than _object_ for an _OrderedDict_? I am not sure.