### PR TITLE
Update fmi_util.pyx

### DIFF
--- a/src/pyfmi/fmi_util.pyx
+++ b/src/pyfmi/fmi_util.pyx
@@ -349,8 +349,8 @@ cpdef convert_sorted_vars_name_desc(list sorted_vars):
     cdef int i, name_length_trial, desc_length_trial, kd, kn
     cdef list desc = [encode("Time in [s]")]
     cdef list name = [encode("time")]
-    cdef int name_length = len(name[0])
-    cdef int desc_length = len(desc[0])
+    cdef int name_length = len(name[0])+1
+    cdef int desc_length = len(desc[0])+1
     cdef char *desc_output
     cdef char *name_output
     cdef char *ctmp_name


### PR DESCRIPTION
Added +1 to lengths of list in order to make sure we have an empty character in the generated string for the default variable time. This is because the function convert_array_names_list_names_int loops through the characters in each variable name and breaks when it finds an empty character, i.e. chr(0). This will resolve issue with the result key for 'time' being displayed as 'tim' instead of desired 'time'. If we don't add +1 we end up with breaking the loop too early when we simulate with options["filter"] set to any value that would exclude all other variables with names longer than 4 characters.