### PR TITLE
Make sure option "logging" works for different solvers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,12 @@
 --- CHANGELOG ---
 --- PyFMI-<TBD> ---
+    * Added support for option 'logging' for different ODE solvers.
+    
+--- PyFMI-2.8.4 ---
+    * Added utility function for determining if the maximum log file
+      size has been reached
     * Added support for parsing boolean values in the XML log parser
-
+    
 --- PyFMI-2.8.3 ---
     * Fixed result saving when saving only the "time" variable
     * Exposed the dependencies kind attributes from FMI 2.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ except ImportError:
 NAME = "PyFMI"
 AUTHOR = "Modelon AB"
 AUTHOR_EMAIL = ""
-VERSION = "trunk"
+VERSION = "2.8.5-dev"
 LICENSE = "LGPL"
 URL = "https://jmodelica.org/pyfmi"
 DOWNLOAD_URL = "https://jmodelica.org/pyfmi/installation.html"

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -627,7 +627,7 @@ cdef class ModelBase:
             
                 number_of_characters --
                     The maximum number of characters in the log.
-                    Default: 1024^3 (about 1GB)
+                    Default: 1024^3*2 (about 2GB)
         """
         self._max_log_size = number_of_characters
         

--- a/src/pyfmi/simulation/assimulo_interface.pyx
+++ b/src/pyfmi/simulation/assimulo_interface.pyx
@@ -1041,7 +1041,8 @@ cdef class FMIODE2(cExplicit_Problem):
                 msg = preface + '  <value name="elapsed_real_time">        %.14E</value>'%(solver.get_elapsed_step_time())
                 self._model.append_log_message("Model", 6, msg)
 
-            if solver_name=="CVode":
+            support_solver_order = solver_name=="CVode" 
+            if support_solver_order:
                 msg = preface + '  <value name="solver_order">%d</value>'%(solver.get_last_order())
                 self._model.append_log_message("Model", 6, msg)
 

--- a/src/pyfmi/simulation/assimulo_interface.pyx
+++ b/src/pyfmi/simulation/assimulo_interface.pyx
@@ -1042,7 +1042,7 @@ cdef class FMIODE2(cExplicit_Problem):
                 self._model.append_log_message("Model", 6, msg)
 
             if solver_name=="CVode":
-                msg = preface + '  <value name="solver_order">%d</value>'%(solver_order)
+                msg = preface + '  <value name="solver_order">%d</value>'%(solver.get_last_order())
                 self._model.append_log_message("Model", 6, msg)
 
             if solver_name=="CVode" or solver_name=="Radau5ODE":

--- a/src/pyfmi/simulation/assimulo_interface.pyx
+++ b/src/pyfmi/simulation/assimulo_interface.pyx
@@ -1123,6 +1123,10 @@ cdef class FMIODE2(cExplicit_Problem):
             msg = preface + '  <boolean name="support_state_errors">%s</boolean>'%support_state_errors
             self._model.append_log_message("Model", 6, msg)
             
+            support_event_indicators = (solver_name=="CVode" or solver_name=="Radau5ODE")   
+            msg = preface + '  <boolean name="support_event_indicators">%s</boolean>'%support_event_indicators
+            self._model.append_log_message("Model", 6, msg)
+            
             support_solver_order = solver_name=="CVode"  
             msg = preface + '  <boolean name="support_solver_order">%s</boolean>'%support_solver_order
             self._model.append_log_message("Model", 6, msg)

--- a/src/pyfmi/simulation/assimulo_interface.pyx
+++ b/src/pyfmi/simulation/assimulo_interface.pyx
@@ -1037,25 +1037,27 @@ cdef class FMIODE2(cExplicit_Problem):
             msg = preface + '<%s>Successful solver step at <value name="t">        %.14E</value>.'%(solver_info_tag, solver.t)
             self._model.append_log_message("Model", 6, msg)
 
-            msg = preface + '  <value name="elapsed_real_time">        %.14E</value>'%(solver.get_elapsed_step_time())
-            self._model.append_log_message("Model", 6, msg)
-
-            solver_order = solver.get_last_order() if solver_name=="CVode" else 5 #hardcoded 5 for other solvers
-            msg = preface + '  <value name="solver_order">%d</value>'%(solver_order)
-            self._model.append_log_message("Model", 6, msg)
-
-            state_errors = ''
-            for i in solver.get_weighted_local_errors():
-                state_errors += "        %.14E,"%i
-            msg = preface + '  <vector name="state_error">' + state_errors[:-1] + '</vector>'
-            self._model.append_log_message("Model", 6, msg)
-
-            if self._g_nbr > 0:
-                msg = preface + '  <vector name="event_indicators">'
-                for i in ev_indicator_values:
-                    msg += "        %.14E,"%i
-                msg = msg[:-1] + '</vector>'# remove last comma
+            if solver.clock_step:
+                msg = preface + '  <value name="elapsed_real_time">        %.14E</value>'%(solver.get_elapsed_step_time())
                 self._model.append_log_message("Model", 6, msg)
+
+            if solver_name=="CVode":
+                msg = preface + '  <value name="solver_order">%d</value>'%(solver_order)
+                self._model.append_log_message("Model", 6, msg)
+
+            if solver_name=="CVode" or solver_name=="Radau5ODE":
+                state_errors = ''
+                for i in solver.get_weighted_local_errors():
+                    state_errors += "        %.14E,"%i
+                msg = preface + '  <vector name="state_error">' + state_errors[:-1] + '</vector>'
+                self._model.append_log_message("Model", 6, msg)
+
+                if self._g_nbr > 0:
+                    msg = preface + '  <vector name="event_indicators">'
+                    for i in ev_indicator_values:
+                        msg += "        %.14E,"%i
+                    msg = msg[:-1] + '</vector>'# remove last comma
+                    self._model.append_log_message("Model", 6, msg)
 
 
             msg = preface + '</%s>'%(solver_info_tag)
@@ -1116,16 +1118,34 @@ cdef class FMIODE2(cExplicit_Problem):
 
             msg = preface + '  <value name="solver_name">%s</value>'%solver_name
             self._model.append_log_message("Model", 6, msg)
-
-            msg = preface + '  <value name="relative_tolerance">%.14E</value>'%solver.rtol
+            
+            support_state_errors = (solver_name=="CVode" or solver_name=="Radau5ODE")   
+            msg = preface + '  <boolean name="support_state_errors">%s</boolean>'%support_state_errors
             self._model.append_log_message("Model", 6, msg)
-
-            atol_values = ''
-            for value in solver.atol:
-                atol_values += '        %.14E,'%value
-            msg = preface + '  <vector name="absolute_tolerance">' + atol_values[:-1] + '</vector>'
+            
+            support_solver_order = solver_name=="CVode"  
+            msg = preface + '  <boolean name="support_solver_order">%s</boolean>'%support_solver_order
             self._model.append_log_message("Model", 6, msg)
+            
+            msg = preface + '  <boolean name="support_elapsed_time">%s</boolean>'%solver.clock_step
+            self._model.append_log_message("Model", 6, msg)
+            
+            support_tol = solver_name != "ExplicitEuler"
+            msg = preface + '  <boolean name="support_tolerances">%s</boolean>'%support_tol
+            self._model.append_log_message("Model", 6, msg)
+            
+            if support_tol:
+                msg = preface + '  <value name="relative_tolerance">%.14E</value>'%solver.rtol
+                self._model.append_log_message("Model", 6, msg)
 
+                atol_values = ''
+                for value in solver.atol:
+                    atol_values += '        %.14E,'%value
+                msg = preface + '  <vector name="absolute_tolerance">' + atol_values[:-1] + '</vector>'
+                self._model.append_log_message("Model", 6, msg)
+
+                       
+            
             msg = preface + '</%s>'%(init_tag)
             self._model.append_log_message("Model", 6, msg)
 
@@ -1141,7 +1161,7 @@ cdef class FMIODE2(cExplicit_Problem):
             f.write("Initial values: y ="+str_y+"\n\n")
 
             header = "Time (simulated) | Time (real) | "
-            if solver_name=="CVode" or solver_name=="Radau5ODE": #Only available for CVode
+            if solver_name=="CVode" or solver_name=="Radau5ODE": #Only available for CVode and Radau5ODE
                 header += "Order | Error (Weighted)"
             f.write(header+"\n")
 

--- a/src/pyfmi/simulation/assimulo_interface.pyx
+++ b/src/pyfmi/simulation/assimulo_interface.pyx
@@ -1045,7 +1045,8 @@ cdef class FMIODE2(cExplicit_Problem):
                 msg = preface + '  <value name="solver_order">%d</value>'%(solver.get_last_order())
                 self._model.append_log_message("Model", 6, msg)
 
-            if solver_name=="CVode" or solver_name=="Radau5ODE":
+            support_state_errors = (solver_name=="CVode" or solver_name=="Radau5ODE") 
+            if support_state_errors:
                 state_errors = ''
                 for i in solver.get_weighted_local_errors():
                     state_errors += "        %.14E,"%i

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -19,6 +19,7 @@ import os
 
 from pyfmi import testattr
 from pyfmi.common.log import extract_xml_log, parse_xml_log
+from pyfmi.tests.test_util import Dummy_FMUModelME2
 
 file_path = os.path.dirname(os.path.abspath(__file__))
 logs = os.path.join(file_path, "files", "Logs")
@@ -64,3 +65,32 @@ class Test_Log:
             log.nodes[1]
         except IndexError: #Test that the log is empty
             pass
+
+    def _test_logging_different_solver(self, solver_name):
+        model = Dummy_FMUModelME2([], "Bouncing_Ball.fmu", os.path.join(file_path, "files", "FMUs", "XML", "ME2.0"), _connect_dll=False)
+        opts=model.simulate_options()
+        opts["logging"] = True
+        opts["solver"] = solver_name
+        model.simulate(options=opts)
+        log_file = model.extract_xml_log()
+        assert os.path.exists(log_file), "Missing log file for {}".format(solver_name)
+
+    @testattr(stddist = True)
+    def test_logging_option_CVode(self):
+        self._test_logging_different_solver("CVode")
+        
+    @testattr(stddist = True)
+    def test_logging_option_Radau5ODE(self):
+        self._test_logging_different_solver("Radau5ODE")
+
+    @testattr(stddist = True)
+    def test_logging_option_ImplicitEuler(self):
+        self._test_logging_different_solver("ImplicitEuler")
+
+    @testattr(stddist = True)
+    def test_logging_option_ExplicitEuler(self):
+        self._test_logging_different_solver("ExplicitEuler")
+
+    @testattr(stddist = True)
+    def test_logging_option_LSODAR(self):
+        self._test_logging_different_solver("LSODAR")


### PR DESCRIPTION
It should be possible to turn on simulate option "logging" for all different kinds of solvers without getting exceptions. The log file should display what is supported.