### PR TITLE
Corrected get_variable_nominal for valueref

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 --- CHANGELOG ---
 --- TBD: Unreleased ---
     * Fixed so that .initial is set properly on ScalarVariable2.
+    * Fixed get_variable_nominal when called for valueref of variable.
     
 --- PyFMI-2.8.5 ---
     * Added support for option 'logging' for different ODE solvers.

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -1962,7 +1962,7 @@ cdef class FMUModelBase(ModelBase):
         
         if _override_erroneous_nominal:
             if variable_name == None:
-                variable_name = self.get_variable_by_valueref(valueref)
+                variable_name = encode(self.get_variable_by_valueref(valueref))
                 variablename = variable_name
                 
             if value == 0.0:

--- a/tests/test_fmi.py
+++ b/tests/test_fmi.py
@@ -119,6 +119,11 @@ class Test_FMUModelME1:
 
         nose.tools.assert_raises(FMUException, bounce.get_variable_by_valueref,7)
     
+    @testattr(stddist = True)
+    def test_get_variable_nominal_valueref(self):
+        bounce = FMUModelME1("bouncingBall.fmu", os.path.join(file_path, "files", "FMUs", "XML", "ME1.0"), _connect_dll=False)
+        assert bounce.get_variable_nominal("v") == bounce.get_variable_nominal(valueref=2)
+
     @testattr(windows_full = True)
     def test_default_experiment(self):
         model = FMUModelME1("CoupledClutches.fmu", os.path.join(file_path, "files", "FMUs", "XML", "ME1.0"), _connect_dll=False)


### PR DESCRIPTION
get_variable_nominal on FMU 1.0 objects returned an exception previously.