### PR TITLE
Allow PARAMETER causality on ME FMUs

### DIFF
--- a/src/pyfmi/simulation/assimulo_interface.pyx
+++ b/src/pyfmi/simulation/assimulo_interface.pyx
@@ -663,8 +663,8 @@ cdef class FMIODE2(cExplicit_Problem):
                 input_names = [input_names]
                 
             for i,name in enumerate(input_names):
-                if self._model.get_variable_causality(name) != fmi.FMI2_INPUT:
-                    raise fmi.FMUException("Variable '%s' is not an input. Only variables specified to be inputs are allowed."%name)
+                if self._model.get_variable_causality(name) not in [fmi.FMI2_INPUT, fmi.FMI2_PARAMETER]:
+                    raise fmi.FMUException("Variable '%s' is not an input/parameter. Only variables specified to be inputs or parameters are allowed."%name)
                 
                 if self._model.get_variable_data_type(name) == fmi.FMI2_REAL:
                     self.input_real_value_refs.append(self._model.get_variable_valueref(name))


### PR DESCRIPTION
Currently pyfmi does not allow to simulate a model-exchange FMU when one decide to set the value of a variable of causality PARAMETER (works fine with CS though).

```
model ParamInput

  parameter Real p1=1.0;
  Real a;
  output Real out1;
  Real d;
equation
  a = p1 + 10;
  out1 = a * 2;
  der(d) = d + 2;
end ParamInput;
```

here is how to run it:
```
import pyfmi
model = pyfmi.load_fmu('ParamInput.fmu')
res = model.simulate(input=(['p1'], lambda t:2*t))
```

one dummy d variable was added with a differential equation to avoid issue #76 when simulating ME models, thanks @Claire-Eleutheriane for the trick
