### PR TITLE
Dont call fmi2_import_get_cont..._states(ndx=NULL)

### DIFF
--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -7921,7 +7921,7 @@ cdef class FMUModelME2(FMUModelBase2):
         if self._nContinuousStates > 0:
             return FMIL.fmi2_import_get_continuous_states(self._fmu, &ndx[0] ,self._nContinuousStates)
         else:
-            return FMIL.fmi2_import_get_continuous_states(self._fmu, NULL ,self._nContinuousStates)
+            return FMIL.fmi2_status_ok
 
     def _get_continuous_states(self):
         """


### PR DESCRIPTION
Following @Claire-Eleutheriane remark in #76, when a ME model is purely
algebraic (i.e. when there is no equation like der(a) = xx):

```
model ParamInput
  input Real p1;
  Real a;
  output Real out1;
equation
  a = p1 + 10;
  out1 = a * 2;
end ParamInput
```

the simulation throws with 'Failed to retrieve the continuous states'
as fmi2_import_get_continuous_states returns error exit code (3)
when ndx=NULL

This does not occur for the fmi1 variant because it uses the address of first element *ndx.data*:
```status = FMIL.fmi1_import_get_continuous_states(self._fmu, <FMIL.fmi1_real_t*>ndx.data, self._nContinuousStates)```
    
Closes #76
