### PR TITLE
Add event check and update for ME2

### DIFF
--- a/src/pyfmi/fmi_algorithm_drivers.py
+++ b/src/pyfmi/fmi_algorithm_drivers.py
@@ -351,7 +351,9 @@ class AssimuloFMIAlg(AlgorithmBase):
             event_info = self.model.get_event_info()
             if event_info.upcomingTimeEvent and event_info.nextEventTime == model.time:
                 self.model.event_update()
-        
+        elif isinstance(self.model, fmi.FMUModelME2):
+            self.model.event_update()
+
         if abs(start_time - model.time) > 1e-14:
             logging.warning('The simulation start time (%f) and the current time in the model (%f) is different. Is the simulation start time correctly set?'%(start_time, model.time))
         


### PR DESCRIPTION
This is for #72.  

In particular, it invokes an event update for an ME2 model at the start time of a simulation.  Currently, it looks like this is only done for ME1.  