### PR TITLE
Added setup.cfg with dependency information

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[options]
+setup_requires =
+    setuptools
+    numpy >= 1.17
+    cython >= 0.29.13
+
+install_requires =
+    numpy >= 1.17
+    scipy >= 1.3
+    cython >= 0.29.13
+    nose >= 1.3.7
+    lxml >= 4.4.1
+    matplotlib > 3
+    assimulo >= 3.2


### PR DESCRIPTION
Setup.cfg contains information of the Python package dependencies in order to build and run PyFMI.