### PR TITLE
Updated import in io.py to avoid deprecation warnings

### DIFF
--- a/src/common/io.py
+++ b/src/common/io.py
@@ -33,7 +33,8 @@ import scipy.io
 from scipy import interpolate
 scipy_minmaj = tuple(map(int, scipy.__version__.split('.')[:2]))
 if scipy_minmaj >= (1, 8):
-    from scipy.io.matlab import MatFile4Reader, VarReader4, convert_dtypes, mdtypes_template, mxSPARSE_CLASS
+    # due to a DeprecationWarning, we do below, this will likely need another change in a future update of scipy.
+    from scipy.io.matlab._mio4 import MatFile4Reader, VarReader4, convert_dtypes, mdtypes_template, mxSPARSE_CLASS
 else:
     from scipy.io.matlab.mio4 import MatFile4Reader, VarReader4, convert_dtypes, mdtypes_template, mxSPARSE_CLASS
 


### PR DESCRIPTION
This PR is created from https://github.com/modelon-community/PyFMI/issues/153#issuecomment-1249099179.  

Due to changes in `scipy` and what is considered to be part of the public API,  the change done to the imports for scipy 1.8.0 and newer did not work. See below (using scipy 1.8.0):  
`
In [1]: from scipy.io.matlab.mio4 import MatFile4Reader  
<ipython-input-1-dd79cb921b16>:1: DeprecationWarning: Please use 'MatFile4Reader' from the 'scipy.io.matlab' namespace, the 'scipy.io.matlab.mio4' namespace is deprecated.  
`
However if you instead try to import `MatFile4Reader` from `scipy.io.matlab` you get an exception because the class does not exist there, see related https://github.com/modelon-community/PyFMI/issues/153#issuecomment-1249099179.