### PR TITLE
Recalculate absolute tolerance when depends on preinit nominal_continuous_states

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,7 @@
 --- CHANGELOG ---
+--- PyFMI-NEXT_VERSION ---
+    * Changed such that absolute tolerances calculated with state nominals retrieved before initialization will be recalculated with state nominals from after initialization when possible.
+
 --- PyFMI-2.10.0 ---
     * Removed the following deprecated functions:
       * pyfmi.fmi.FMUModelCS1, FMUModelME1, FMUModelCS2, FMUModelME2, pyfmi.fmi.FMUModelME1Extended: get_log_file_name: use get_log_filename

--- a/src/pyfmi/fmi.pxd
+++ b/src/pyfmi/fmi.pxd
@@ -158,6 +158,7 @@ cdef class FMUModelME1(FMUModelBase):
     cpdef _get_time(self)
     cpdef _set_time(self, FMIL.fmi1_real_t t)
     cpdef get_derivatives(self)
+    cdef int __get_nominal_continuous_states(self, FMIL.fmi1_real_t* xnominal, size_t nx)
 
 cdef class FMUModelBase2(ModelBase):
     """
@@ -253,6 +254,7 @@ cdef class FMUModelME2(FMUModelBase2):
     cdef int __set_continuous_states(self, FMIL.fmi2_real_t[:] ndx)
     cdef int _get_event_indicators(self, FMIL.fmi2_real_t[:] values)
     cdef int _completed_integrator_step(self, int* enter_event_mode, int* terminate_simulation)
+    cdef int __get_nominal_continuous_states(self, FMIL.fmi2_real_t* xnominal, size_t nx)
 
 cdef class WorkerClass2:
     cdef int _dim

--- a/src/pyfmi/fmi.pxd
+++ b/src/pyfmi/fmi.pxd
@@ -161,6 +161,9 @@ cdef class FMUModelME1(FMUModelBase):
     cdef int __get_nominal_continuous_states(self, FMIL.fmi1_real_t* xnominal, size_t nx)
     cdef public object _preinit_nominal_continuous_states
 
+cdef class __ForTestingFMUModelME1(FMUModelME1):
+    cpdef set_allocated_fmu(self, int value)
+
 cdef class FMUModelBase2(ModelBase):
     """
     FMI Model loaded from a dll.

--- a/src/pyfmi/fmi.pxd
+++ b/src/pyfmi/fmi.pxd
@@ -135,6 +135,7 @@ cdef class FMUModelBase(ModelBase):
     cdef public list _save_bool_variables_val
     cdef int _fmu_kind
     cdef char* _fmu_temp_dir
+    cdef public object _pre_init_nominal_continuous_states
 
     cpdef _internal_set_fmu_null(self)
     cpdef get_variable_description(self, variablename)
@@ -267,3 +268,6 @@ cdef class WorkerClass2:
     cdef N.ndarray get_value_reference_numpy_vector(self, int index)
     cdef N.ndarray get_real_numpy_vector(self, int index)
     cpdef verify_dimensions(self, int dim)
+
+cdef class __ForTestingFMUModelME2(FMUModelME2):
+    cpdef set_initialized_fmu(self, int value)

--- a/src/pyfmi/fmi.pxd
+++ b/src/pyfmi/fmi.pxd
@@ -135,7 +135,6 @@ cdef class FMUModelBase(ModelBase):
     cdef public list _save_bool_variables_val
     cdef int _fmu_kind
     cdef char* _fmu_temp_dir
-    cdef public object _pre_init_nominal_continuous_states
 
     cpdef _internal_set_fmu_null(self)
     cpdef get_variable_description(self, variablename)
@@ -160,6 +159,7 @@ cdef class FMUModelME1(FMUModelBase):
     cpdef _set_time(self, FMIL.fmi1_real_t t)
     cpdef get_derivatives(self)
     cdef int __get_nominal_continuous_states(self, FMIL.fmi1_real_t* xnominal, size_t nx)
+    cdef public object _preinit_nominal_continuous_states
 
 cdef class FMUModelBase2(ModelBase):
     """
@@ -256,6 +256,7 @@ cdef class FMUModelME2(FMUModelBase2):
     cdef int _get_event_indicators(self, FMIL.fmi2_real_t[:] values)
     cdef int _completed_integrator_step(self, int* enter_event_mode, int* terminate_simulation)
     cdef int __get_nominal_continuous_states(self, FMIL.fmi2_real_t* xnominal, size_t nx)
+    cdef public object _preinit_nominal_continuous_states
 
 cdef class WorkerClass2:
     cdef int _dim

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -3465,7 +3465,6 @@ cdef class FMUModelME1(FMUModelBase):
 
         # Fallback - auto-correct the illegal nominal values:
         xvrs = self.get_state_value_references()
-        # TODO: What about xvrs[i] == fmiUndefinedValueReference?
         for i in range(self._nContinuousStates):
             if xn[i] == 0.0:
                 if self.callbacks.log_level >= FMIL.jm_log_level_warning:

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -3551,7 +3551,8 @@ cdef class FMUModelME1(FMUModelBase):
         the FMI specification, atol = 0.01*rtol*(nominal values of the
         continuous states).
 
-        This method should not be called before initialization, since it depends on state nominals.
+        This method should not be called before initialization, since it depends on state nominals
+        which can change during initialization.
 
         Returns::
 
@@ -7885,7 +7886,8 @@ cdef class FMUModelME2(FMUModelBase2):
         the FMI specification, atol = 0.01*rtol*(nominal values of the
         continuous states).
 
-        This method should not be called before initialization, since it depends on state nominals.
+        This method should not be called before initialization, since it depends on state nominals
+        which can change during initialization.
 
         Returns::
 

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -3519,6 +3519,8 @@ cdef class FMUModelME1(FMUModelBase):
         the FMI specification, atol = 0.01*rtol*(nominal values of the
         continuous states).
 
+        This method should not be called before initialization, since it depends on state nominals.
+
         Returns::
 
             rtol --
@@ -3531,10 +3533,39 @@ cdef class FMUModelME1(FMUModelBase):
 
             [rtol, atol] = model.get_tolerances()
         """
-        rtol = self.get_default_experiment_tolerance()
-        atol = 0.01*rtol*self.nominal_continuous_states
+        rtol = self.get_relative_tolerance()
+        atol = self.get_absolute_tolerances()
 
         return [rtol, atol]
+
+    def get_relative_tolerance(self):
+        """
+        Returns the relative tolerance. If the relative tolerance
+        is defined in the XML-file it is used, otherwise a default of 1.e-4 is
+        used.
+
+        Returns::
+
+            rtol --
+                The relative tolerance.
+        """
+        return self.get_default_experiment_tolerance()
+
+    def get_absolute_tolerances(self):
+        """
+        Returns the absolute tolerances. They are calculated and returned according to
+        the FMI specification, atol = 0.01*rtol*(nominal values of the
+        continuous states)
+
+        This method should not be called before initialization, since it depends on state nominals.
+
+        Returns::
+
+            atol --
+                The absolute tolerances.
+        """
+        rtol = self.get_relative_tolerance()
+        return 0.01*rtol*self.nominal_continuous_states
 
     def event_update(self, intermediateResult=False):
         """
@@ -7799,6 +7830,8 @@ cdef class FMUModelME2(FMUModelBase2):
         the FMI specification, atol = 0.01*rtol*(nominal values of the
         continuous states).
 
+        This method should not be called before initialization, since it depends on state nominals.
+
         Returns::
 
             rtol --
@@ -7811,11 +7844,39 @@ cdef class FMUModelME2(FMUModelBase2):
 
             [rtol, atol] = model.get_tolerances()
         """
-
-        rtol = self.get_default_experiment_tolerance()
-        atol = 0.01*rtol*self.nominal_continuous_states
+        rtol = self.get_relative_tolerance()
+        atol = self.get_absolute_tolerances()
 
         return [rtol, atol]
+
+    def get_relative_tolerance(self):
+        """
+        Returns the relative tolerance. If the relative tolerance
+        is defined in the XML-file it is used, otherwise a default of 1.e-4 is
+        used.
+
+        Returns::
+
+            rtol --
+                The relative tolerance.
+        """
+        return self.get_default_experiment_tolerance()
+
+    def get_absolute_tolerances(self):
+        """
+        Returns the absolute tolerances. They are calculated and returned according to
+        the FMI specification, atol = 0.01*rtol*(nominal values of the
+        continuous states)
+
+        This method should not be called before initialization, since it depends on state nominals.
+
+        Returns::
+
+            atol --
+                The absolute tolerances.
+        """
+        rtol = self.get_relative_tolerance()
+        return 0.01*rtol*self.nominal_continuous_states
 
     cdef int _completed_integrator_step(self, int* enter_event_mode, int* terminate_simulation):
         cdef int status

--- a/src/pyfmi/fmi_algorithm_drivers.py
+++ b/src/pyfmi/fmi_algorithm_drivers.py
@@ -94,20 +94,20 @@ class AssimuloFMIAlgOptions(OptionBase):
 
         with_jacobian --
             Determines if the Jacobian should be computed from PyFMI (using
-            either the directional derivatives, if available, or estimed using
+            either the directional derivatives, if available, or estimated using
             finite differences) or if the Jacobian should be computed by the
-            choosen solver. The default is to use PyFMI if directional
-            derivatives are available, otherwise computed by the choosen
+            chosen solver. The default is to use PyFMI if directional
+            derivatives are available, otherwise computed by the chosen
             solver.
             Default: "Default"
 
         dynamic_diagnostics --
             If True, enables logging of diagnostics data to the binary result file. This requires that
             the option 'result_handler' is an instance of ResultHandlerBinaryFile, otherwise an exception is raised.
-            Model variable names are not allowed to start with 'Diagnostics'using this option
+            Model variable names are not allowed to start with 'Diagnostics' using this option
             and a check for this is performed before simulation start. If this criteria is not
             met an exception is raised.
-            The diagnostics data will be available via the simulation resuls and/or the
+            The diagnostics data will be available via the simulation results and/or the
             binary result file generated during simulation.
             Default: False
 
@@ -239,7 +239,7 @@ class AssimuloFMIAlgOptions(OptionBase):
 
 class AssimuloFMIAlg(AlgorithmBase):
     """
-    Simulation algortihm for FMUs using the Assimulo package.
+    Simulation algorithm for FMUs using the Assimulo package.
     """
 
     def __init__(self,
@@ -361,7 +361,7 @@ class AssimuloFMIAlg(AlgorithmBase):
             try:
                 rtol = self.solver_options['rtol']
             except KeyError:
-                rtol, atol = self.model.get_tolerances()
+                rtol = self.model.get_relative_tolerance()
 
             if isinstance(self.model, fmi.FMUModelME1):
                 self.model.time = start_time #Set start time before initialization
@@ -383,6 +383,8 @@ class AssimuloFMIAlg(AlgorithmBase):
             raise fmi.FMUException("Setup Experiment has not been called, this has to be called prior to the initialization call.")
         elif self.model.time is None:
             raise fmi.FMUException("The model need to be initialized prior to calling the simulate method if the option 'initialize' is set to False")
+
+        self._set_absolute_tolerance_options()
 
         if isinstance(self.result_handler, ResultHandlerBinaryFile):
             self._setup_diagnostics_variables()
@@ -562,24 +564,13 @@ class AssimuloFMIAlg(AlgorithmBase):
             if self.options['logging']:
                 self.solver_options['clock_step'] = True
 
-        #Check relative tolerance
-        #If the tolerances are not set specifically, they are set
-        #according to the 'DefaultExperiment' from the XML file.
+        # Check relative tolerance
+        # If the tolerances are not set specifically, they are set
+        # according to the 'DefaultExperiment' from the XML file.
         try:
             if isinstance(self.solver_options["rtol"], str) and self.solver_options["rtol"] == "Default":
-                rtol, atol = self.model.get_tolerances()
+                rtol = self.model.get_relative_tolerance()
                 self.solver_options['rtol'] = rtol
-        except KeyError:
-            pass
-
-        #Check absolute tolerance
-        try:
-            if isinstance(self.solver_options["atol"], str) and self.solver_options["atol"] == "Default":
-                fnbr, gnbr = self.model.get_ode_sizes()
-                if fnbr == 0:
-                    self.solver_options['atol'] = 0.01*self.solver_options['rtol']
-                else:
-                    self.solver_options['atol'] = 0.01*self.solver_options['rtol']*self.model.nominal_continuous_states
         except KeyError:
             pass
 
@@ -604,6 +595,22 @@ class AssimuloFMIAlg(AlgorithmBase):
                                 self.solver_options["linear_solver"] = "SPARSE"
                 else:
                     self.with_jacobian = False
+
+    def _set_absolute_tolerance_options(self):
+        """
+        Sets the absolute tolerance. Must not be called before initialization since it depends on nominals.
+
+        Assumes some initial setup has been done via previous call to _set_options.
+        """
+        try:
+            if isinstance(self.solver_options["atol"], str) and self.solver_options["atol"] == "Default":
+                fnbr, _ = self.model.get_ode_sizes()
+                if fnbr == 0:
+                    self.solver_options['atol'] = 0.01*self.solver_options['rtol']
+                else:
+                    self.solver_options['atol'] = 0.01*self.solver_options['rtol']*self.model.nominal_continuous_states
+        except KeyError:
+            pass
 
     def _set_solver_options(self):
         """
@@ -887,7 +894,7 @@ class FMICSAlgOptions(OptionBase):
 
 class FMICSAlg(AlgorithmBase):
     """
-    Simulation algortihm for FMUs (Co-simulation).
+    Simulation algorithm for FMUs (Co-simulation).
     """
 
     def __init__(self,
@@ -897,7 +904,7 @@ class FMICSAlg(AlgorithmBase):
                  model,
                  options):
         """
-        Simulation algortihm for FMUs (Co-simulation).
+        Simulation algorithm for FMUs (Co-simulation).
 
         Parameters::
 
@@ -1174,7 +1181,7 @@ class FMICSAlg(AlgorithmBase):
 
 class SciEstAlg(AlgorithmBase):
     """
-    Estimation algortihm for FMUs.
+    Estimation algorithm for FMUs.
     """
 
     def __init__(self,
@@ -1184,7 +1191,7 @@ class SciEstAlg(AlgorithmBase):
                  model,
                  options):
         """
-        Estimation algortihm for FMUs .
+        Estimation algorithm for FMUs.
 
         Parameters::
 
@@ -1248,7 +1255,7 @@ class SciEstAlg(AlgorithmBase):
             self.options["simulate_options"] = self.model.simulate_options()
 
         #Modifiy necessary options:
-        self.options["simulate_options"]['ncp']    = self.measurements[1].shape[0] - 1 #Store at the same points as measurment data
+        self.options["simulate_options"]['ncp']    = self.measurements[1].shape[0] - 1 #Store at the same points as measurement data
         self.options["simulate_options"]['filter'] = self.measurements[0] #Only store the measurement variables (efficiency)
 
         if "solver" in self.options["simulate_options"]:

--- a/src/pyfmi/fmi_algorithm_drivers.py
+++ b/src/pyfmi/fmi_algorithm_drivers.py
@@ -623,8 +623,7 @@ class AssimuloFMIAlg(AlgorithmBase):
                 factors = atol / preinit_nominals
                 f0 = factors[0]
                 for f in factors:
-                    if abs(f0 - f) > f0 * 1e-6:  # REVIEW: How to do this properly?
-                        # REVIEW: Should this give warning? In Case 2 we mention something about it, but hard to understand.
+                    if abs(f0 - f) > f0 * 1e-6:
                         return
                 # Success.
                 self.solver_options["atol"] = atol * self.model.nominal_continuous_states / preinit_nominals

--- a/src/pyfmi/fmi_coupled.pyx
+++ b/src/pyfmi/fmi_coupled.pyx
@@ -1788,6 +1788,7 @@ cdef class CoupledFMUModelME2(CoupledFMUModelBase):
     cdef public object _order, _blocks
     cdef public object _values_continuous_states_changed
     cdef public object _nominals_continuous_states_changed
+    cdef public object _preinit_nominal_continuous_states
     
     def __init__(self, models, connections):
         """
@@ -1828,6 +1829,9 @@ cdef class CoupledFMUModelME2(CoupledFMUModelBase):
         
         self._values_continuous_states_changed = False
         self._nominals_continuous_states_changed = False                                     
+
+        # State nominals retrieved before initialization
+        self._preinit_nominal_continuous_states = None
     
     cpdef _get_time(self):
         """

--- a/src/pyfmi/fmi_coupled.pyx
+++ b/src/pyfmi/fmi_coupled.pyx
@@ -2063,6 +2063,8 @@ cdef class CoupledFMUModelME2(CoupledFMUModelBase):
         the FMI specification, atol = 0.01*rtol*(nominal values of the
         continuous states).
 
+        This method should not be called before initialization, since it depends on state nominals.
+
         Returns::
 
             rtol --
@@ -2075,13 +2077,42 @@ cdef class CoupledFMUModelME2(CoupledFMUModelBase):
 
             [rtol, atol] = model.get_tolerances()
         """
-        rtol = 0.0
-        for model in self.models:
-            rtol = max(rtol, model.get_default_experiment_tolerance())
-        atol = 0.01*rtol*self.nominal_continuous_states
+        rtol = self.get_relative_tolerance()
+        atol = self.get_absolute_tolerances()
 
         return [rtol, atol]
 
+    def get_relative_tolerance(self):
+        """
+        Returns the relative tolerance. If the relative tolerance
+        is defined in the XML-file it is used, otherwise a default of 1.e-4 is
+        used.
+
+        Returns::
+
+            rtol --
+                The relative tolerance.
+        """
+        rtol = 0.0
+        for model in self.models:
+            rtol = max(rtol, model.get_default_experiment_tolerance())
+        return rtol
+
+    def get_absolute_tolerances(self):
+        """
+        Returns the absolute tolerances. They are calculated and returned according to
+        the FMI specification, atol = 0.01*rtol*(nominal values of the
+        continuous states)
+
+        This method should not be called before initialization, since it depends on state nominals.
+
+        Returns::
+
+            atol --
+                The absolute tolerances.
+        """
+        rtol = self.get_relative_tolerance()
+        return 0.01*rtol*self.nominal_continuous_states
 
     def completed_integrator_step(self, no_set_FMU_state_prior_to_current_point = True):
         """

--- a/tests/test_fmi.py
+++ b/tests/test_fmi.py
@@ -36,7 +36,12 @@ from pyfmi.common.algorithm_drivers import UnrecognizedOptionError
 from pyfmi.common.core import create_temp_dir
 
 
-class TempAlg(AssimuloFMIAlg):
+class NoSolveAlg(AssimuloFMIAlg):
+    """
+    Algorithm that skips the solve step. Typically necessary to test DummyFMUs that
+    don't have an implementation that can handle that step.
+    """
+
     def solve(self):
         pass
 
@@ -140,7 +145,7 @@ if assimulo_installed:
 
             opts["CVode_options"]["atol"] = 0.01 * model.nominal_continuous_states
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.02, 0.01])
-            model.simulate(options=opts, algorithm=TempAlg)
+            model.simulate(options=opts, algorithm=NoSolveAlg)
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.03])
 
         @testattr(stddist = True)
@@ -152,7 +157,7 @@ if assimulo_installed:
 
             opts["CVode_options"]["atol"] = (0.01 * model.nominal_continuous_states) + [0.01, 0.01]
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.02])
-            model.simulate(options=opts, algorithm=TempAlg)
+            model.simulate(options=opts, algorithm=NoSolveAlg)
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.02])
 
         @testattr(stddist = True)
@@ -164,7 +169,7 @@ if assimulo_installed:
 
             opts["CVode_options"]["atol"] = [0.02, 0.01]
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.02, 0.01])
-            model.simulate(options=opts, algorithm=TempAlg)
+            model.simulate(options=opts, algorithm=NoSolveAlg)
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.02, 0.01])
 
         # NOTE:
@@ -769,7 +774,7 @@ if assimulo_installed:
 
             def run_case(expected, default="Default"):
                 model.reset()
-                res = model.simulate(final_time=1.5,options=opts, algorithm=TempAlg)
+                res = model.simulate(final_time=1.5,options=opts, algorithm=NoSolveAlg)
                 assert res.options["with_jacobian"] == default, res.options["with_jacobian"]
                 assert res.solver.problem._with_jacobian == expected, res.solver.problem._with_jacobian
 
@@ -806,7 +811,7 @@ if assimulo_installed:
 
                 model.get_ode_sizes = lambda: (fnbr, 0)
 
-                res = model.simulate(final_time=1.5,options=opts, algorithm=TempAlg)
+                res = model.simulate(final_time=1.5,options=opts, algorithm=NoSolveAlg)
                 assert res.solver.problem._with_jacobian == expected_jacobian, res.solver.problem._with_jacobian
                 assert res.solver.linear_solver == expected_sparse, res.solver.linear_solver
 
@@ -879,7 +884,7 @@ if assimulo_installed:
                 else:
                     expected = (float(tstop)-float(tstart))/float(opts["ncp"])
 
-                res = model.simulate(start_time=tstart, final_time=tstop,options=opts, algorithm=TempAlg)
+                res = model.simulate(start_time=tstart, final_time=tstop,options=opts, algorithm=NoSolveAlg)
                 assert res.solver.maxh == expected, res.solver.maxh
                 assert res.options[solver+"_options"]["maxh"] == "Default", res.options[solver+"_options"]["maxh"]
 
@@ -908,7 +913,7 @@ if assimulo_installed:
 
             opts["CVode_options"]["atol"] = 0.01 * model.nominal_continuous_states
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.02, 0.01])
-            model.simulate(options=opts, algorithm=TempAlg)
+            model.simulate(options=opts, algorithm=NoSolveAlg)
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.03])
 
         @testattr(stddist = True)
@@ -920,7 +925,7 @@ if assimulo_installed:
 
             opts["CVode_options"]["atol"] = (0.01 * model.nominal_continuous_states) + [0.01, 0.01]
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.02])
-            model.simulate(options=opts, algorithm=TempAlg)
+            model.simulate(options=opts, algorithm=NoSolveAlg)
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.02])
 
         @testattr(stddist = True)
@@ -932,7 +937,7 @@ if assimulo_installed:
 
             opts["CVode_options"]["atol"] = [0.02, 0.01]
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.02, 0.01])
-            model.simulate(options=opts, algorithm=TempAlg)
+            model.simulate(options=opts, algorithm=NoSolveAlg)
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.02, 0.01])
 
         @testattr(stddist = True)
@@ -947,7 +952,7 @@ if assimulo_installed:
             opts["initialize"] = False
             opts["CVode_options"]["atol"] = 0.01 * model.nominal_continuous_states
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.03])
-            model.simulate(options=opts, algorithm=TempAlg)
+            model.simulate(options=opts, algorithm=NoSolveAlg)
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.03])
 
         @testattr(stddist = True)
@@ -958,7 +963,7 @@ if assimulo_installed:
             model, opts = self.setup_atol_auto_update_test_base()
             
             opts["CVode_options"]["rtol"] = 1e-6
-            model.simulate(options=opts, algorithm=TempAlg)
+            model.simulate(options=opts, algorithm=NoSolveAlg)
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [3e-8, 3e-8])
 
         @testattr(stddist = True)
@@ -971,7 +976,7 @@ if assimulo_installed:
             opts["CVode_options"]["rtol"] = 1e-9
             opts["CVode_options"]["atol"] = 0.01 * model.nominal_continuous_states
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.02, 0.01])
-            model.simulate(options=opts, algorithm=TempAlg)
+            model.simulate(options=opts, algorithm=NoSolveAlg)
             np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.03])
 
 

--- a/tests/test_fmi.py
+++ b/tests/test_fmi.py
@@ -238,7 +238,7 @@ class Test_FMUModelME1:
     @testattr(stddist = True)
     def test_get_xxx_empty(self):
         """ Test that get_xxx([]) do not calls do not trigger calls to FMU. """
-        model = FMUModelME1("bouncingBall.fmu", os.path.join(file_path, "files", "FMUs", "XML", "ME1.0"), _connect_dll=False)
+        model = FMUModelME1(os.path.join(file_path, "files", "FMUs", "XML", "ME1.0", "bouncingBall.fmu"), _connect_dll=False)
         ## Tests that these do not crash and return empty arrays/lists
         assert len(model.get_real([]))    == 0, "get_real   ([]) has non-empty return"
         assert len(model.get_integer([])) == 0, "get_integer([]) has non-empty return"
@@ -1043,7 +1043,7 @@ class Test_FMUModelME2:
     @testattr(stddist = True)
     def test_get_xxx_empty(self):
         """ Test that get_xxx([]) do not calls do not trigger calls to FMU. """
-        model = FMUModelME2("bouncingBall.fmu", os.path.join(file_path, "files", "FMUs", "XML", "ME2.0"), _connect_dll=False)
+        model = FMUModelME2(os.path.join(file_path, "files", "FMUs", "XML", "ME2.0", "bouncingBall.fmu"), _connect_dll=False)
         ## Tests that these do not crash and return empty arrays/lists
         assert len(model.get_real([]))    == 0, "get_real   ([]) has non-empty return"
         assert len(model.get_integer([])) == 0, "get_integer([]) has non-empty return"

--- a/tests/test_fmi.py
+++ b/tests/test_fmi.py
@@ -532,7 +532,6 @@ class Test_FMUModelBase:
         one_off_test_logging = False
 
         model = Dummy_FMUModelME1([], FMU_PATHS.ME1.coupled_clutches, log_level=3, _connect_dll=False)
-        model.initialize()
 
         if one_off_test_logging:
             log_stream = StringIO()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -218,7 +218,6 @@ class Dummy_FMUModelME2(__ForTestingFMUModelME2):
 
     # Values for nominal_continuous_states. 'test_sparse_option()' and more tests will break
     # if the values are not calculated from get_ode_sizes() as defined at __init__.
-    # REVIEW: Can we fix the tests instead? I don't know how to.
     _nominal_continuous_states = None
 
     #Override properties

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,12 +19,13 @@ import nose
 import os
 import numpy as np
 
-from pyfmi.fmi import FMUException, FMUModelME1, FMUModelCS1, load_fmu, FMUModelCS2, FMUModelME2, __ForTestingFMUModelME2
+from pyfmi.fmi import FMUException, FMUModelME1, __ForTestingFMUModelME1, FMUModelCS1, load_fmu, \
+                      FMUModelCS2, FMUModelME2, __ForTestingFMUModelME2
 
 def get_examples_folder():
     return os.path.join(os.path.dirname(__file__), '..', 'examples')
 
-class Dummy_FMUModelME1(FMUModelME1):
+class Dummy_FMUModelME1(__ForTestingFMUModelME1):
     #Override properties
     time = None
     continuous_states = None
@@ -200,7 +201,7 @@ class Dummy_FMUModelME2(__ForTestingFMUModelME2):
     continuous_states = None
     nominal_continuous_states = None
 
-    def __init__(self, negated_aliases, *args,**kwargs):
+    def __init__(self, negated_aliases, *args, **kwargs):
         FMUModelME2.__init__(self, *args, **kwargs)
 
         self.continuous_states = np.zeros(self.get_ode_sizes()[0])


### PR DESCRIPTION
A common workflow in PyFMI is that absolute tolerances are calculated with model.nominal_continuous_states, but that it's set before initialization. This is incorrect when the nominals are calculated after initialization.

This PR adds a heuristic that automatically tries to recalculate atol with state nominals from after initialization.