### PR TITLE
Avoid fmi2_import_get_derivatives with NULL array

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 --- PyFMI-2.10.4 ---
     * Added 'result_handling' = None as option, deprecated 'none'.
     * Fixed so that 'hasattr' works on log nodes.
+    * Attempts to get continuous states derivatives when there are no such states will now return fmi2_status_ok instead of an error.
 
 --- PyFMI-2.10.3 ---
     * Added method to retrieve the unbounded attribute for real variables in FMI2: get_variable_unbounded.

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -8118,7 +8118,7 @@ cdef class FMUModelME2(FMUModelBase2):
         if self._nContinuousStates > 0:
             return FMIL.fmi2_import_get_derivatives(self._fmu, &values[0], self._nContinuousStates)
         else:
-            return FMIL.fmi2_import_get_derivatives(self._fmu, NULL, self._nContinuousStates)
+            return FMIL.fmi2_status_ok
 
     cpdef get_derivatives(self):
         """


### PR DESCRIPTION
Closes #184, similar fix as in #92

Do you know why _nContinuousStates is zero in ME mode ?

cc @modelonrobinandersson 