### PR TITLE
Don't call FMU when calling get_derivatives when there are no states.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 --- PyFMI-2.10.4 ---
     * Added 'result_handling' = None as option, deprecated 'none'.
     * Fixed so that 'hasattr' works on log nodes.
+    * Attempts to get continuous states derivatives when there are no such states will now return fmi2_status_ok instead of an error.
 
 --- PyFMI-2.10.3 ---
     * Added method to retrieve the unbounded attribute for real variables in FMI2: get_variable_unbounded.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 --- PyFMI-2.10.4 ---
     * Added 'result_handling' = None as option, deprecated 'none'.
     * Fixed so that 'hasattr' works on log nodes.
-    * Attempts to get continuous states derivatives when there are no such states will now return fmi2_status_ok instead of an error.
+    * Calls to get continuous states derivatives when there are no such states will no longer result in FMU calls.
 
 --- PyFMI-2.10.3 ---
     * Added method to retrieve the unbounded attribute for real variables in FMI2: get_variable_unbounded.

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -3420,7 +3420,7 @@ cdef class FMUModelME1(FMUModelBase):
         if self._nContinuousStates > 0:
             status = FMIL.fmi1_import_get_continuous_states(self._fmu, <FMIL.fmi1_real_t*>ndx.data ,self._nContinuousStates)
         else:
-            status = FMIL.fmi1_status_ok
+            return ndx
 
         if status != 0:
             raise FMUException('Failed to retrieve the continuous states.')

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -3416,7 +3416,11 @@ cdef class FMUModelME1(FMUModelBase):
     def _get_continuous_states(self):
         cdef int status
         cdef N.ndarray[double, ndim=1,mode='c'] ndx = N.zeros(self._nContinuousStates, dtype=N.double)
-        status = FMIL.fmi1_import_get_continuous_states(self._fmu, <FMIL.fmi1_real_t*>ndx.data ,self._nContinuousStates)
+
+        if self._nContinuousStates > 0:
+            status = FMIL.fmi1_import_get_continuous_states(self._fmu, <FMIL.fmi1_real_t*>ndx.data ,self._nContinuousStates)
+        else:
+            status = FMIL.fmi1_status_ok
 
         if status != 0:
             raise FMUException('Failed to retrieve the continuous states.')

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -3416,11 +3416,7 @@ cdef class FMUModelME1(FMUModelBase):
     def _get_continuous_states(self):
         cdef int status
         cdef N.ndarray[double, ndim=1,mode='c'] ndx = N.zeros(self._nContinuousStates, dtype=N.double)
-
-        if self._nContinuousStates > 0:
-            status = FMIL.fmi1_import_get_continuous_states(self._fmu, <FMIL.fmi1_real_t*>ndx.data ,self._nContinuousStates)
-        else:
-            return ndx
+        status = FMIL.fmi1_import_get_continuous_states(self._fmu, <FMIL.fmi1_real_t*>ndx.data ,self._nContinuousStates)
 
         if status != 0:
             raise FMUException('Failed to retrieve the continuous states.')
@@ -3513,7 +3509,10 @@ cdef class FMUModelME1(FMUModelBase):
         cdef int status
         cdef N.ndarray[FMIL.fmi1_real_t, ndim=1,mode='c'] values = N.empty(self._nContinuousStates,dtype=N.double)
 
-        status = FMIL.fmi1_import_get_derivatives(self._fmu, <FMIL.fmi1_real_t*>values.data, self._nContinuousStates)
+        if self._nContinuousStates > 0:
+            status = FMIL.fmi1_import_get_derivatives(self._fmu, <FMIL.fmi1_real_t*>values.data, self._nContinuousStates)
+        else:
+            return values
 
         if status != 0:
             raise FMUException('Failed to get the derivative values at time: %E.'%self.time)

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -8118,7 +8118,7 @@ cdef class FMUModelME2(FMUModelBase2):
         if self._nContinuousStates > 0:
             return FMIL.fmi2_import_get_derivatives(self._fmu, &values[0], self._nContinuousStates)
         else:
-            return FMIL.fmi2_import_get_derivatives(self._fmu, NULL, self._nContinuousStates)
+            return FMIL.fmi2_status_ok
 
     cpdef get_derivatives(self):
         """


### PR DESCRIPTION
See also: https://github.com/modelon-community/PyFMI/pull/185