### PR TITLE
Allow to build without distutils

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 --- PyFMI-2.13.1 ---
     * Numpy 2.x support
+    * Allow to build without distutils for Python>=3.12 support
 
 --- PyFMI-2.13.0 ---
     * Upgraded to Cython3.


### PR DESCRIPTION
Allows to use Python 3.12
it drops the no_msvcr and prefix options (that can be worked around with building the wheel then using pip --target-dir)