### PR TITLE
Updated interface to get_variables_data

### DIFF
--- a/src/common/io.py
+++ b/src/common/io.py
@@ -1354,6 +1354,9 @@ class ResultDymolaBinary(ResultDymola):
             start_index = max(0, start_index)
             stop_index = max(0, nbr_points if stop_index is None else min(nbr_points, stop_index))
             new_file_position = file_position + start_index*sizeof_type*nbr_variables
+            # Finally when stop_index = None, we can end up with start > stop,
+            # therefore we need to use min(start, stop)
+            start_index = min(start_index, stop_index)
             new_nbr_points = stop_index - start_index
 
             self._data_2[data_index] = fmi_util.read_trajectory(
@@ -1601,7 +1604,6 @@ class ResultDymolaBinary(ResultDymola):
         if isinstance(start_index, int) and isinstance(stop_index, int) and stop_index < start_index:
             raise ValueError(f"Invalid values for {start_index=} and {stop_index=}, " + \
                               "'start_index' needs to be less than or equal to 'stop_index'.")
-
 
         trajectories = {}
 

--- a/src/common/io.py
+++ b/src/common/io.py
@@ -1619,7 +1619,7 @@ class ResultDymolaBinary(ResultDymola):
         for name in names:
             trajectories[name] = self._get_variable_data_as_trajectory(name, time, start_index, stop_index)
 
-        new_start_index = start_index + len(time) if len(trajectories) > 0 else None
+        new_start_index = stop_index if len(trajectories) > 0 else None
         self._last_set_of_indices = (start_index, stop_index) # update them before we exit
         return trajectories, new_start_index
 

--- a/src/common/io.py
+++ b/src/common/io.py
@@ -1622,7 +1622,7 @@ class ResultDymolaBinary(ResultDymola):
         largest_trajectory_length = -1
         for v, t in trajectories.items():
             largest_trajectory_length = max(largest_trajectory_length, len(t.x))
-        new_start_index = start_index + largest_trajectory_length if len(trajectories) > 0 else None
+        new_start_index = start_index + largest_trajectory_length if trajectories else None
 
         self._last_set_of_indices = (start_index, stop_index) # update them before we exit
         return trajectories, new_start_index

--- a/src/common/io.py
+++ b/src/common/io.py
@@ -1619,7 +1619,11 @@ class ResultDymolaBinary(ResultDymola):
         for name in names:
             trajectories[name] = self._get_variable_data_as_trajectory(name, time, start_index, stop_index)
 
-        new_start_index = stop_index if len(trajectories) > 0 else None
+        largest_trajectory_length = -1
+        for v, t in trajectories.items():
+            largest_trajectory_length = max(largest_trajectory_length, len(t.x))
+        new_start_index = start_index + largest_trajectory_length if len(trajectories) > 0 else None
+
         self._last_set_of_indices = (start_index, stop_index) # update them before we exit
         return trajectories, new_start_index
 

--- a/src/common/io.py
+++ b/src/common/io.py
@@ -1343,7 +1343,6 @@ class ResultDymolaBinary(ResultDymola):
             index_in_cache = data_index in self._data_2
             partial_cache_ok = self._can_use_partial_cache(start_index, stop_index)
             if (index_in_cache and not self._allow_file_updates) or (index_in_cache and partial_cache_ok):
-                print(f"Doing an early return")
                 return self._data_2[data_index]
 
             file_position  = self._data_2_info["file_position"]
@@ -1352,12 +1351,10 @@ class ResultDymolaBinary(ResultDymola):
             nbr_variables  = self._data_2_info["nbr_variables"]
 
             # Account for sub-sets of data
-            print(f"{start_index=}, {stop_index=}")
             start_index = max(0, start_index)
             stop_index = max(0, nbr_points if stop_index is None else min(nbr_points, stop_index))
             new_file_position = file_position + start_index*sizeof_type*nbr_variables
             new_nbr_points = stop_index - start_index
-            print(f"{start_index=}, {stop_index=}, {new_nbr_points=}")
 
             self._data_2[data_index] = fmi_util.read_trajectory(
                 encode(self._fname),

--- a/src/common/io.py
+++ b/src/common/io.py
@@ -1622,7 +1622,10 @@ class ResultDymolaBinary(ResultDymola):
 
         # If stop_index > number of data points, and data gets added while we are iterating
         # then we might get trajectories of unequal lengths. Therefore ensure we set stop_index here accordingly.
-        stop_index = min(len(time) + start_index, float('inf') if stop_index is None else stop_index)
+        if stop_index is None:
+            stop_index = len(time) + start_index
+        else:
+            stop_index = min(len(time) + start_index, stop_index)
 
         for name in names:
             trajectories[name] = self._get_variable_data_as_trajectory(name, time, start_index, stop_index)

--- a/src/common/io.py
+++ b/src/common/io.py
@@ -1642,11 +1642,7 @@ class ResultDymolaBinary(ResultDymola):
             among the set of continuous variables. We disregard parameters/constants since they are not stored
             with the same amount of data points as trajectories for continuous variables.
         """
-        length = 0
-        for var_name, trajectory in trajectories.items():
-            if self.is_variable(var_name): # since we only consider continuous variables
-                length = max(length, len(trajectory.x))
-        return length
+        return max([0] + [len(t.x) for v, t in trajectories.items() if self.is_variable(v)])
 
     def _calculate_events_and_steps(self, name):
         if name in self._data_3:

--- a/src/common/io.py
+++ b/src/common/io.py
@@ -2532,9 +2532,6 @@ class ResultSizeError(JIOError):
     Exception that is raised when a set maximum result size is exceeded.
     """
 
-class InvalidIndexError(JIOError):
-    """ Exception that is raised when indices for variable trajectories are invalid. """
-
 def robust_float(value):
     """
     Function for robust handling of float values such as INF and NAN.

--- a/src/pyfmi/fmi.pyx
+++ b/src/pyfmi/fmi.pyx
@@ -692,7 +692,7 @@ cdef class ModelBase:
 
         if self._additional_logger:
             self._additional_logger(module, log_level, message)
-        
+
         if self._max_log_size_msg_sent:
             return
 
@@ -4583,7 +4583,7 @@ cdef class FMUModelBase2(ModelBase):
 
         if nref == 0: ## get_string([])
             return []
-        
+
         cdef FMIL.fmi2_string_t* output_value = <FMIL.fmi2_string_t*>FMIL.malloc(sizeof(FMIL.fmi2_string_t)*nref)
 
         self._log_handler.capi_start_callback(self._max_log_size_msg_sent, self._current_log_size)
@@ -4977,7 +4977,7 @@ cdef class FMUModelBase2(ModelBase):
     def set_debug_logging(self, logging_on, categories = []):
         """
         Specifies if the debugging should be turned on or off and calls fmi2SetDebugLogging
-        for the specified categories, after checking they are valid. 
+        for the specified categories, after checking they are valid.
 
         Parameters::
 
@@ -5827,7 +5827,7 @@ cdef class FMUModelBase2(ModelBase):
         relative_quantity = FMIL.fmi2_import_get_real_variable_relative_quantity(real_variable)
 
         return relative_quantity == FMI2_TRUE
-    
+
     cpdef get_variable_unbounded(self, variable_name):
         """
         Get the unbounded attribute of a real variable.
@@ -7853,7 +7853,7 @@ cdef class FMUModelME2(FMUModelBase2):
         Deallocate memory allocated
         """
         self._invoked_dealloc = 1
-        
+
         if self._initialized_fmu == 1:
             FMIL.fmi2_import_terminate(self._fmu)
 
@@ -9067,8 +9067,8 @@ cdef class LogHandler:
         pass
 
 cdef class LogHandlerDefault(LogHandler):
-    """Default LogHandler that uses checkpoints around FMI CAPI calls to 
-    ensure logs are truncated at checkpoints. For FMUs generating XML during 
+    """Default LogHandler that uses checkpoints around FMI CAPI calls to
+    ensure logs are truncated at checkpoints. For FMUs generating XML during
     CAPI calls, this ensures valid XML. """
     def __init__(self, max_log_size):
         super().__init__(max_log_size)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1930,6 +1930,30 @@ class TestResultDymolaBinary:
             (rdb.get_variables_data(['h'], 495, 502)[0]['h'].x),
             np.array([0.37268813, 0.37194424, 0.37120184, 0.37046092, 0.36972148, 0.36898351]))
 
+
+    @testattr(stddist = True)
+    def test_trajectory_lengths(self):
+        """ Verify lengths of trajectories are expected for a bunch of different inputs. """
+        fmu = Dummy_FMUModelME2([], os.path.join(file_path, "files", "FMUs", "XML", "ME2.0", "bouncingBall.fmu"), _connect_dll=False)
+        res = fmu.simulate()
+        assert len(res['h']) == 501
+        rdb = ResultDymolaBinary(fmu.get_last_result_file(), allow_file_updates = True)
+        assert len(rdb.get_variables_data(['h'], 495, 496)[0]['h'].x) == 1
+        assert len(rdb.get_variables_data(['h'], 495, 500)[0]['h'].x) == 5
+        assert len(rdb.get_variables_data(['h'], 495, 499)[0]['h'].x) == 4
+        assert len(rdb.get_variables_data(['h'], 495, 501)[0]['h'].x) == 6
+        assert len(rdb.get_variables_data(['h'], 495, 502)[0]['h'].x) == 6
+        # a couple of repeated values to verify the cache is not being used
+        assert len(rdb.get_variables_data(['h'], 0, None)[0]['h'].x) == 501
+        assert len(rdb.get_variables_data(['h'], 0, 5)[0]['h'].x) == 5
+        assert len(rdb.get_variables_data(['h'], 0, None)[0]['h'].x) == 501
+        assert len(rdb.get_variables_data(['h'], 0, 5)[0]['h'].x) == 5
+        assert len(rdb.get_variables_data(['h'], 0, 5)[0]['h'].x) == 5
+
+        assert len(rdb.get_variables_data(['h'], 5, 15)[0]['h'].x) == 10
+        assert len(rdb.get_variables_data(['h'], 0, 550)[0]['h'].x) == 501
+        assert len(rdb.get_variables_data(['h'], 0, 10000)[0]['h'].x) == 501
+
 if assimulo_installed:
     class TestFileSizeLimit:
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1954,6 +1954,12 @@ class TestResultDymolaBinary:
         assert len(rdb.get_variables_data(['h'], 0, 550)[0]['h'].x) == 501
         assert len(rdb.get_variables_data(['h'], 0, 10000)[0]['h'].x) == 501
 
+        # test different scenarios of start_index out of bounds
+        assert len(rdb.get_variables_data(['h'], 501, 502)[0]['h'].x) == 0
+        assert len(rdb.get_variables_data(['h'], 501, None)[0]['h'].x) == 0
+        assert len(rdb.get_variables_data(['h'], 501)[0]['h'].x) == 0
+        assert len(rdb.get_variables_data(['h'], 1234567)[0]['h'].x) == 0
+
 if assimulo_installed:
     class TestFileSizeLimit:
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1960,6 +1960,11 @@ class TestResultDymolaBinary:
         assert len(rdb.get_variables_data(['h'], 501)[0]['h'].x) == 0
         assert len(rdb.get_variables_data(['h'], 1234567)[0]['h'].x) == 0
 
+        # Verify next_start_index also for no variables is equal to start_index
+        assert rdb.get_variables_data([], start_index = 0)[1] == 0
+        assert rdb.get_variables_data([], start_index = 1)[1] == 1
+        assert rdb.get_variables_data([], start_index = 5)[1] == 5
+
 if assimulo_installed:
     class TestFileSizeLimit:
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1793,7 +1793,7 @@ class TestResultDymolaBinary:
                 fmu.set('J4.phi', f(fmu.time)) # arbitrary
 
             trajectories, start_index = rdb.get_variables_data(vars_to_test, start_index, stop_index_function(start_index))
-            data_to_return[i] = [t.x for t in trajectories]
+            data_to_return[i] = trajectories.copy()
 
         assert data_to_return, "Something went wrong, no test data was generated"
         return data_to_return
@@ -1811,7 +1811,7 @@ class TestResultDymolaBinary:
         }
 
         for index, test_data in test_data_sets.items():
-            np.testing.assert_array_almost_equal(test_data[0], reference_data[index])
+            np.testing.assert_array_almost_equal(test_data['J4.phi'].x, reference_data[index])
 
     @testattr(stddist = True)
     def test_get_variables_data_values1(self):
@@ -1830,7 +1830,7 @@ class TestResultDymolaBinary:
         # Just verify results for J4.phi here, but we retrieve all four trajectories at once
         # to see that it works
         for index, test_data in test_data_sets.items():
-            np.testing.assert_array_almost_equal(test_data[1], reference_data[index])
+            np.testing.assert_array_almost_equal(test_data['J4.phi'].x, reference_data[index])
 
     @testattr(stddist = True)
     def test_get_variables_data_values2(self):
@@ -1847,7 +1847,7 @@ class TestResultDymolaBinary:
         }
 
         for index, test_data in test_data_sets.items():
-            np.testing.assert_array_almost_equal(test_data[1], reference_data[index])
+            np.testing.assert_array_almost_equal(test_data['J4.phi'].x, reference_data[index])
 
     def test_get_variables_data_values3(self):
         """ Verifing values from get_variables_data, and only asking for diagnostic variables. """
@@ -1872,8 +1872,8 @@ class TestResultDymolaBinary:
         }
 
         for index, test_data in test_data_sets.items():
-            np.testing.assert_array_almost_equal(test_data[0], reference_data['@Diagnostics.step_time'][index])
-            np.testing.assert_array_almost_equal(test_data[1], reference_data['@Diagnostics.nbr_steps'][index])
+            np.testing.assert_array_almost_equal(test_data['@Diagnostics.step_time'].x, reference_data['@Diagnostics.step_time'][index])
+            np.testing.assert_array_almost_equal(test_data['@Diagnostics.nbr_steps'].x, reference_data['@Diagnostics.nbr_steps'][index])
 
     def test_get_variables_data_values4(self):
         """ Verifing values from get_variables_data, partial trajectories and checking both time and diagnostic data."""
@@ -1898,8 +1898,8 @@ class TestResultDymolaBinary:
         }
 
         for index, test_data in test_data_sets.items():
-            np.testing.assert_array_almost_equal(test_data[0], reference_data['time'][index])
-            np.testing.assert_array_almost_equal(test_data[1], reference_data['@Diagnostics.nbr_steps'][index])
+            np.testing.assert_array_almost_equal(test_data['time'].x, reference_data['time'][index])
+            np.testing.assert_array_almost_equal(test_data['@Diagnostics.nbr_steps'].x, reference_data['@Diagnostics.nbr_steps'][index])
 
 if assimulo_installed:
     class TestFileSizeLimit:
@@ -1909,7 +1909,7 @@ if assimulo_installed:
                 model = Dummy_FMUModelME2([], os.path.join(file_path, "files", "FMUs", "XML", "ME2.0", "CoupledClutches.fmu"), _connect_dll=False)
             else:
                 model = Dummy_FMUModelCS2([], os.path.join(file_path, "files", "FMUs", "XML", "CS2.0", "CoupledClutches.fmu"), _connect_dll=False)
-                
+
             opts = model.simulate_options()
             opts["result_handling"]  = result_type
             opts["result_file_name"] = result_file_name
@@ -1973,7 +1973,7 @@ if assimulo_installed:
 
             assert file_size > max_size*0.9 and file_size < max_size*1.1, \
                    "The file size is not within 10% of the given max size"
-        
+
         def _test_result_size_early_abort(self, result_type, result_file_name=""):
             """
             Verifies that the ResultSizeError is triggered and also verifies that the cause of the error being
@@ -1994,7 +1994,7 @@ if assimulo_installed:
 
                 assert file_size < max_size*0.1, \
                         "The file size is not small, no early abort"
-        
+
         # TODO: Pytest parametrization
         """
         Binary
@@ -2005,11 +2005,11 @@ if assimulo_installed:
             Make sure that the diagnostics variables are also taken into account.
             """
             self._test_result_size_verification("binary", dynamic_diagnostics=True)
-            
+
         @testattr(stddist = True)
         def test_binary_file_size_verification(self):
             self._test_result_size_verification("binary")
-        
+
         @testattr(stddist = True)
         def test_binary_file_size_early_abort(self):
             self._test_result_size_early_abort("binary")
@@ -2017,11 +2017,11 @@ if assimulo_installed:
         @testattr(stddist = True)
         def test_small_size_binary_file(self):
             self._test_result_exception("binary")
-        
+
         @testattr(stddist = True)
         def test_small_size_binary_file_cs(self):
             self._test_result_exception("binary", fmi_type="cs")
-        
+
         @testattr(stddist = True)
         def test_small_size_binary_file_stream(self):
             self._test_result_exception("binary", BytesIO())
@@ -2040,7 +2040,7 @@ if assimulo_installed:
         @testattr(stddist = True)
         def test_text_file_size_verification(self):
             self._test_result_size_verification("file")
-        
+
         @testattr(stddist = True)
         def test_text_file_size_early_abort(self):
             self._test_result_size_early_abort("file")
@@ -2048,7 +2048,7 @@ if assimulo_installed:
         @testattr(stddist = True)
         def test_small_size_text_file(self):
             self._test_result_exception("file")
-        
+
         @testattr(stddist = True)
         def test_small_size_text_file_stream(self):
             self._test_result_exception("file", StringIO())
@@ -2067,7 +2067,7 @@ if assimulo_installed:
         @testattr(stddist = True)
         def test_csv_file_size_verification(self):
             self._test_result_size_verification("csv")
-        
+
         @testattr(stddist = True)
         def test_csv_file_size_early_abort(self):
             self._test_result_size_early_abort("csv")
@@ -2075,7 +2075,7 @@ if assimulo_installed:
         @testattr(stddist = True)
         def test_small_size_csv_file(self):
             self._test_result_exception("csv")
-        
+
         @testattr(stddist = True)
         def test_small_size_csv_file_stream(self):
             self._test_result_exception("csv", StringIO())
@@ -2094,11 +2094,11 @@ if assimulo_installed:
         @testattr(stddist = True)
         def test_small_size_memory(self):
             self._test_result_exception("memory")
-        
+
         @testattr(stddist = True)
         def test_memory_size_early_abort(self):
             self._test_result_size_early_abort("memory")
-        
+
         @testattr(stddist = True)
         def test_small_size_memory_stream(self):
             self._test_result_exception("memory", StringIO())


### PR DESCRIPTION
Accounts for invalid range of start_index and stop_index, also returns a dict instead of a list.
Fixes issue with cached data for partial trajectories.