### PR TITLE
Clarifying option description that filter only apples to model variables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
 --- CHANGELOG ---
 --- PyFMI-FUTURE ---
-    * Changed default log and file size limiations from 2 GiB (2*1024**3) to 2 GB (2e9).
+    * Changed default log and file size limitations from 2 GiB (2*1024**3) to 2 GB (2e9).
       Updated the corresponding error messages to correctly reference sizes in GB instead of GiB.
+    * Clarified that the `filter` option only applies to model variables.
 
 --- PyFMI-2.16.2 ---
     * Increased robustness of getting the `supports` attribute from ResultHandlers.

--- a/src/pyfmi/fmi_algorithm_drivers.py
+++ b/src/pyfmi/fmi_algorithm_drivers.py
@@ -151,7 +151,7 @@ class AssimuloFMIAlgOptions(OptionBase):
             Default: True
 
         filter --
-            A filter for choosing which variables to actually store
+            A filter for choosing which model variables to actually store
             result for. The syntax can be found in
             http://en.wikipedia.org/wiki/Glob_%28programming%29 . An
             example is filter = "*der" , stor all variables ending with
@@ -845,7 +845,7 @@ class FMICSAlgOptions(OptionBase):
             Default: none
 
         filter --
-            A filter for choosing which variables to actually store
+            A filter for choosing which model variables to actually store
             result for. The syntax can be found in
             http://en.wikipedia.org/wiki/Glob_%28programming%29 . An
             example is filter = "*der" , stor all variables ending with

--- a/src/pyfmi/master.pyx
+++ b/src/pyfmi/master.pyx
@@ -294,13 +294,13 @@ class MasterAlgOptions(OptionBase):
         result_handler --
             The handler for the result. Depending on the option in
             result_handling this either defaults to ResultHandlerFile
-            or ResultHandlerMemory. If result_handling custom is choosen
+            or ResultHandlerMemory. If result_handling custom is chosen
             This MUST be provided and be a dictionary with model name as 'key'
             and the ResultHandler instance for that model as 'value'.
             Default: None
 
         filter --
-            A filter for choosing which variables to actually store
+            A filter for choosing which model variables to actually store
             result for. The syntax can be found in
             http://en.wikipedia.org/wiki/Glob_%28programming%29 . An
             example is filter = "*der" , stor all variables ending with
@@ -317,7 +317,7 @@ class MasterAlgOptions(OptionBase):
             If True, store additionally the values in the underlying 
             FMUs to the result file before data has been exchange 
             between the connected models. The values will always be 
-            stored after data has been exhanged between the connected
+            stored after data has been exchanged between the connected
             models.
             Default: False
         
@@ -342,7 +342,7 @@ class MasterAlgOptions(OptionBase):
             <result_downsampling_factor>-th communication point.
             Start & end point are always included.
             Affects results storing from the 'store_step_before_update' option.
-            Useage with 'error_controlled' = True is not supported.
+            Usage with 'error_controlled' = True is not supported.
             Example: If set to 2: Result contains only every other communication point.
             Default: 1 (no downsampling)
     """
@@ -419,7 +419,7 @@ cdef class Master:
                       Needs to be a subclass of FMUModelCS.
                       
             connection  
-                    - Specifices the connection between the models.
+                    - Specifies the connection between the models.
                         
                     - model_begin.variable -> model_accept.variable
                       [(model_source,"beta",model_destination,"y"),(...)]


### PR DESCRIPTION
I'm hoping that "model variables" sufficiently clarifies that this filter would e.g., not apply to @Diagnostics variables from `dynamic_diagnostics`. (Would like to avoid explicitly stating that, which would only create more cross dependencies)