### PR TITLE
Fixed Exception when using dynamic_diagnostics and scalar atol

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 --- CHANGELOG ---
 --- PyFMI-FUTURE ---
     * Increased robustness of getting the `supports` attribute from ResultHandlers.
+    * Fixed an Exception when using `dynamic_diagnostics` and scalar `atol`.
 
 --- PyFMI-2.16.1 ---
     * Fixed an issue with `get_variables_data` returning full trajectories when mixed with `get_variable_data` calls.

--- a/src/common/diagnostics.py
+++ b/src/common/diagnostics.py
@@ -70,7 +70,11 @@ def setup_diagnostics_variables(model, start_time, options, solver_options):
                 atol = [atol]*len(states_list)
             # atol is "pseudoscalar", array/list with single entry; 
             if np.size(atol) == 1:
-                atol = [atol[0]]*len(states_list)
+                # distinction here is need since e.g., np.array(1.) does not support indexing
+                if isinstance(atol, np.ndarray):
+                    atol = [atol.item()]*len(states_list)
+                else: # general iterable, e.g., list
+                    atol = [atol[0]]*len(states_list)
                 
             _diagnostics_params[f"{DIAGNOSTICS_PREFIX}solver.relative_tolerance"] = (rtol, "Relative solver tolerance.")
 

--- a/src/common/diagnostics.py
+++ b/src/common/diagnostics.py
@@ -19,6 +19,7 @@
 ## This file contains various components for the 'dynamics_diagnostics' options
 
 from pyfmi.fmi import FMUModelME2
+import numpy as np
 import numbers
 
 DIAGNOSTICS_PREFIX = '@Diagnostics.'
@@ -63,8 +64,13 @@ def setup_diagnostics_variables(model, start_time, options, solver_options):
             atol = solver_options.get('atol', None)
             if (rtol is None) or (atol is None):
                 rtol, atol = model.get_tolerances()
-            if isinstance(atol, numbers.Number): # is atol is scalar, convert to list
+            
+            # is atol is scalar, convert to list
+            if isinstance(atol, numbers.Number): 
                 atol = [atol]*len(states_list)
+            # atol is "pseudoscalar", array/list with single entry; 
+            if np.size(atol) == 1:
+                atol = [atol[0]]*len(states_list)
                 
             _diagnostics_params[f"{DIAGNOSTICS_PREFIX}solver.relative_tolerance"] = (rtol, "Relative solver tolerance.")
 

--- a/src/common/diagnostics.py
+++ b/src/common/diagnostics.py
@@ -19,6 +19,7 @@
 ## This file contains various components for the 'dynamics_diagnostics' options
 
 from pyfmi.fmi import FMUModelME2
+import numbers
 
 DIAGNOSTICS_PREFIX = '@Diagnostics.'
 
@@ -62,6 +63,8 @@ def setup_diagnostics_variables(model, start_time, options, solver_options):
             atol = solver_options.get('atol', None)
             if (rtol is None) or (atol is None):
                 rtol, atol = model.get_tolerances()
+            if isinstance(atol, numbers.Number): # is atol is scalar, convert to list
+                atol = [atol]*len(states_list)
                 
             _diagnostics_params[f"{DIAGNOSTICS_PREFIX}solver.relative_tolerance"] = (rtol, "Relative solver tolerance.")
 

--- a/tests/test_fmi.py
+++ b/tests/test_fmi.py
@@ -1117,7 +1117,7 @@ class Test_FMUModelME2_Simulation:
         model.simulate(options=opts, algorithm=NoSolveAlg)
         np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.03])
 
-    @pytest.mark.parametrize("atol", [1e-4, [1e-4], np.array([1e-4])])
+    @pytest.mark.parametrize("atol", [1e-4, [1e-4], np.array([1e-4]), np.array(1e-4), (1e-4)])
     def test_dynamic_diagnostics_scalar_atol(self, atol):
         """Test scalar atol + dynamic_diagnostics."""
         model = Dummy_FMUModelME2([], FMU_PATHS.ME2.nominal_test4, _connect_dll=False)

--- a/tests/test_fmi.py
+++ b/tests/test_fmi.py
@@ -210,13 +210,13 @@ class Test_FMUModelME1:
         err_msg = "The FMU could not be loaded."
         fmu = os.path.join(file_path, "files", "FMUs", "XML", "ME1.0", "RLC_Circuit.fmu")
         with pytest.raises(InvalidBinaryException, match = err_msg):
-            model = FMUModelME1(fmu, _connect_dll=True)
+            FMUModelME1(fmu, _connect_dll=True)
 
     def test_invalid_version(self):
         err_msg = "This class only supports FMI 1.0"
         fmu = os.path.join(file_path, "files", "FMUs", "XML", "ME2.0", "LinearStability.SubSystem2.fmu")
         with pytest.raises(InvalidVersionException, match = err_msg):
-            model = FMUModelME1(fmu, _connect_dll=True)
+            FMUModelME1(fmu, _connect_dll=True)
 
     def test_get_time_varying_variables(self):
         model = FMUModelME1(os.path.join(file_path, "files", "FMUs", "XML", "ME1.0", "RLC_Circuit.fmu"), _connect_dll=False)
@@ -1117,6 +1117,16 @@ class Test_FMUModelME2_Simulation:
         model.simulate(options=opts, algorithm=NoSolveAlg)
         np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.03])
 
+    def test_dynamic_diagnostics_scalar_atol(self):
+        """Test scalar atol + dynamic_diagnostics."""
+        model = Dummy_FMUModelME2([], FMU_PATHS.ME2.nominal_test4, _connect_dll=False)
+
+        opts = model.simulate_options()
+        solver = "CVode"
+        opts[f"{solver}_options"]["atol"] = 1e-4
+        opts["dynamic_diagnostics"] = True
+
+        model.simulate(options = opts)
 
 class Test_FMUModelME2:
     def test_unzipped_fmu_exception_invalid_dir(self):

--- a/tests/test_fmi.py
+++ b/tests/test_fmi.py
@@ -1117,13 +1117,14 @@ class Test_FMUModelME2_Simulation:
         model.simulate(options=opts, algorithm=NoSolveAlg)
         np.testing.assert_allclose(opts["CVode_options"]["atol"], [0.03, 0.03])
 
-    def test_dynamic_diagnostics_scalar_atol(self):
+    @pytest.mark.parametrize("atol", [1e-4, [1e-4], np.array([1e-4])])
+    def test_dynamic_diagnostics_scalar_atol(self, atol):
         """Test scalar atol + dynamic_diagnostics."""
         model = Dummy_FMUModelME2([], FMU_PATHS.ME2.nominal_test4, _connect_dll=False)
 
         opts = model.simulate_options()
         solver = "CVode"
-        opts[f"{solver}_options"]["atol"] = 1e-4
+        opts[f"{solver}_options"]["atol"] = atol
         opts["dynamic_diagnostics"] = True
 
         model.simulate(options = opts)


### PR DESCRIPTION
I considered that the conversion of scalar atol to list could also be done in the `_set_absolute_tolerance_options` function (in `fmi_algorithm_drivers.py`). 

I do however prefer this variant since the adjustment is close to where it is needed. The other variant would create an unnecessary convoluted dependency in the code.