### PR TITLE
Implemented FMI3 get & set for float32/64 variables

### DIFF
--- a/src/pyfmi/fmi3.pxd
+++ b/src/pyfmi/fmi3.pxd
@@ -17,6 +17,9 @@
 
 # Module containing the FMI3 interface Python wrappers.
 
+import numpy as np
+cimport numpy as np
+
 cimport pyfmi.fmil_import as FMIL
 cimport pyfmi.fmil3_import as FMIL3
 cimport pyfmi.fmi_base as FMI_BASE
@@ -40,6 +43,15 @@ cdef class FMUModelBase3(FMI_BASE.ModelBase):
 
     cdef int _initialized_fmu
     cdef object  _has_entered_init_mode # this is public in FMI2 but I don't see why
+
+    cpdef set_float64(self, valueref, values)
+    cpdef set_float32(self, valueref, values)
+
+    cpdef np.ndarray get_float64(self, valueref)
+    cpdef np.ndarray get_float32(self, valueref)
+
+    cpdef FMIL3.fmi3_value_reference_t get_variable_valueref(self, variablename) except *
+    cpdef FMIL3.fmi3_base_type_enu_t get_variable_data_type(self, variable_name) except *
 
 cdef class FMUModelME3(FMUModelBase3):
     cdef FMIL.size_t                _nEventIndicators

--- a/src/pyfmi/fmi3.pyx
+++ b/src/pyfmi/fmi3.pyx
@@ -361,12 +361,12 @@ cdef class FMUModelBase3(FMI_BASE.ModelBase):
 
     cpdef set_float64(self, valueref, values):
         """
-        Sets the float64-values in the FMU as defined by the valuereference(s).
+        Sets the float64-values in the FMU as defined by the value reference(s).
 
         Parameters::
 
             valueref --
-                A list of valuereferences.
+                A list of value references.
 
             values --
                 Values to be set.
@@ -380,6 +380,9 @@ cdef class FMUModelBase3(FMI_BASE.ModelBase):
         cdef int status
         cdef np.ndarray[FMIL3.fmi3_value_reference_t, ndim=1, mode='c'] input_valueref = np.asarray(valueref, dtype = np.uint32).ravel()
         cdef np.ndarray[FMIL3.fmi3_float64_t, ndim=1, mode='c'] set_value = np.asarray(values, dtype = np.double).ravel()
+
+        if np.size(input_valueref) != np.size(set_value):
+            raise FMUException('The length of valueref and values are inconsistent. Note: Array variables are not yet supported')
 
         self._log_handler.capi_start_callback(self._max_log_size_msg_sent, self._current_log_size)
         status = FMIL3.fmi3_import_set_float64(
@@ -396,12 +399,12 @@ cdef class FMUModelBase3(FMI_BASE.ModelBase):
 
     cpdef set_float32(self, valueref, values):
         """
-        Sets the float32-values in the FMU as defined by the valuereference(s).
+        Sets the float32-values in the FMU as defined by the value reference(s).
 
         Parameters::
 
             valueref --
-                A list of valuereferences.
+                A list of value references.
 
             values --
                 Values to be set.
@@ -415,6 +418,9 @@ cdef class FMUModelBase3(FMI_BASE.ModelBase):
         cdef int status
         cdef np.ndarray[FMIL3.fmi3_value_reference_t, ndim=1, mode='c'] input_valueref = np.asarray(valueref, dtype = np.uint32).ravel()
         cdef np.ndarray[FMIL3.fmi3_float32_t, ndim=1, mode='c'] set_value = np.asarray(values, dtype = np.float32).ravel()
+
+        if np.size(input_valueref) != np.size(set_value):
+            raise FMUException('The length of valueref and values are inconsistent. Note: Array variables are not yet supported')
 
         self._log_handler.capi_start_callback(self._max_log_size_msg_sent, self._current_log_size)
         status = FMIL3.fmi3_import_set_float32(
@@ -449,12 +455,12 @@ cdef class FMUModelBase3(FMI_BASE.ModelBase):
 
     cpdef np.ndarray get_float64(self, valueref):
         """
-        Returns the float64-values from the valuereference(s).
+        Returns the float64-values from the value reference(s).
 
         Parameters::
 
             valueref --
-                A list of valuereferences.
+                A list of value references.
 
         Returns::
 
@@ -494,12 +500,12 @@ cdef class FMUModelBase3(FMI_BASE.ModelBase):
 
     cpdef np.ndarray get_float32(self, valueref):
         """
-        Returns the float32-values from the valuereference(s).
+        Returns the float32-values from the value reference(s).
 
         Parameters::
 
             valueref --
-                A list of valuereferences.
+                A list of value references.
 
         Returns::
 
@@ -539,7 +545,7 @@ cdef class FMUModelBase3(FMI_BASE.ModelBase):
 
     cpdef FMIL3.fmi3_value_reference_t get_variable_valueref(self, variable_name) except *:
         """
-        Extract the ValueReference given a variable name.
+        Extract the value reference given a variable name.
 
         Parameters::
 
@@ -548,7 +554,7 @@ cdef class FMUModelBase3(FMI_BASE.ModelBase):
 
         Returns::
 
-            The ValueReference for the variable passed as argument.
+            The value reference for the variable passed as argument.
         """
         cdef FMIL3.fmi3_import_variable_t* variable
         cdef FMIL3.fmi3_value_reference_t vr

--- a/src/pyfmi/fmil3_import.pxd
+++ b/src/pyfmi/fmil3_import.pxd
@@ -21,20 +21,43 @@
 # This file contains FMIL header content specific to FMI3
 cimport pyfmi.fmil_import as FMIL
 from libcpp cimport bool # TODO: Possible issue due to https://github.com/cython/cython/issues/5730 ??
-
+from libc.stdint cimport uint32_t
 
 
 cdef extern from 'fmilib.h':
     # FMI VARIABLE TYPE DEFINITIONS
-    ctypedef void*  fmi3_instance_environment_t
-    ctypedef char*  fmi3_string_t
-    ctypedef bool   fmi3_boolean_t
-    ctypedef double fmi3_float64_t
+    ctypedef void*    fmi3_instance_environment_t
+    ctypedef char*    fmi3_string_t
+    ctypedef bool     fmi3_boolean_t
+    ctypedef double   fmi3_float64_t
+    ctypedef float    fmi3_float32_t
+    ctypedef uint32_t fmi3_value_reference_t
 
     # STRUCTS
     ctypedef enum fmi3_boolean_enu_t:
         fmi3_true = 1
         fmi3_false = 0
+
+    cdef enum fmi3_base_type_enu_t:
+        fmi3_base_type_float64 = 1,
+        fmi3_base_type_float32 = 2,
+        fmi3_base_type_int64   = 3,
+        fmi3_base_type_int32   = 4,
+        fmi3_base_type_int16   = 5,
+        fmi3_base_type_int8    = 6,
+        fmi3_base_type_uint64  = 7,
+        fmi3_base_type_uint32  = 8,
+        fmi3_base_type_uint16  = 9,
+        fmi3_base_type_uint8   = 10,
+        fmi3_base_type_bool    = 11,
+        fmi3_base_type_binary  = 12,
+        fmi3_base_type_clock   = 13,
+        fmi3_base_type_str     = 14,
+        fmi3_base_type_enum    = 15
+
+    cdef struct fmi3_xml_variable_t:
+        pass
+    ctypedef fmi3_xml_variable_t fmi3_import_variable_t
 
     # STATUS
     cdef enum fmi3_fmu_kind_enu_t:
@@ -102,7 +125,13 @@ cdef extern from 'fmilib.h':
     # setting
     fmi3_status_t fmi3_import_set_time(fmi3_import_t *, fmi3_float64_t)
 
+    fmi3_status_t fmi3_import_set_float64(fmi3_import_t*, fmi3_value_reference_t*, size_t, fmi3_float64_t*, size_t)
+    fmi3_status_t fmi3_import_set_float32(fmi3_import_t*, fmi3_value_reference_t*, size_t, fmi3_float32_t*, size_t)
+
     # getting
+    fmi3_status_t fmi3_import_get_float64(fmi3_import_t*, fmi3_value_reference_t*, size_t, fmi3_float64_t*, size_t);
+    fmi3_status_t fmi3_import_get_float32(fmi3_import_t*, fmi3_value_reference_t*, size_t, fmi3_float32_t*, size_t);
+
     double fmi3_import_get_default_experiment_start(fmi3_import_t*);
     double fmi3_import_get_default_experiment_stop(fmi3_import_t*);
     double fmi3_import_get_default_experiment_tolerance(fmi3_import_t*);
@@ -133,3 +162,8 @@ cdef extern from 'fmilib.h':
     void fmi3_log_forwarding(fmi3_instance_environment_t, fmi3_status_t, fmi3_string_t, fmi3_string_t)
     char* fmi3_import_get_last_error(fmi3_import_t*)
     char* fmi3_import_get_model_identifier_ME(fmi3_import_t*)
+
+    # Getting variables attributes/types
+    fmi3_import_variable_t* fmi3_import_get_variable_by_name(fmi3_import_t*, char*)
+    fmi3_value_reference_t fmi3_import_get_variable_vr(fmi3_import_variable_t*)
+    fmi3_base_type_enu_t fmi3_import_get_variable_base_type(fmi3_import_variable_t*)

--- a/tests/test_fmi3.py
+++ b/tests/test_fmi3.py
@@ -382,6 +382,15 @@ class Test_FMI3ME:
         with pytest.raises(FMUException, match = err_msg):
             fmu.get_variable_data_type(var_name)
 
+    def test_set_array_variable(self):
+        """Test setting an array variable (not yet supported). """
+        fmu_path = FMI3_REF_FMU_PATH / "StateSpace.fmu"
+        fmu = FMUModelME3(fmu_path)
+        err_msg = "The length of valueref and values are inconsistent. Note: Array variables are not yet supported"
+        with pytest.raises(FMUException, match = err_msg):
+            fmu.set("x", np.array([1, 2, 3]))
+
+
 class TestFMI3CS:
     # TODO: Unsupported for now
     pass

--- a/tests/test_fmi3.py
+++ b/tests/test_fmi3.py
@@ -17,11 +17,8 @@
 
 import pytest
 import re
-<<<<<<< HEAD
 import logging
-=======
 import numpy as np
->>>>>>> 3b67cc5 (Implemented get & set for float32/64 variables)
 from io import StringIO
 from pyfmi import load_fmu
 from pathlib import Path


### PR DESCRIPTION
Array variables introduce a bit of complication; when setting/getting them, one needs to check dimensions first to reserve appropriate output buffer sizes or compute the correct length of the inputs. 

Omitted them for now, we'd likely want to add some convenience functionality in fmi-library for that, e.g., get the summed dimensions for a list of value references.