### PR TITLE
Fixed race condition for trajectory reading

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 --- CHANGELOG ---
 --- PyFMI-FUTURE ---
     * Fixed an issue for dynamic_diagnostics, where failures to evaluate the Jacobian would result in invalid XML.
+    * Fixed a race-condition in using ResultDymolaBinary.get_variables_data().
 
 --- PyFMI-2.17.1 ---
     * Fixed compilation issue with Cython 3.1.

--- a/src/common/io.py
+++ b/src/common/io.py
@@ -1412,7 +1412,8 @@ class ResultDymolaBinary(ResultDymola):
             note that 'read_diag_data' is a boolean used when this function is invoked for
             diagnostic variables.
         """
-        self._verify_file_data()
+        # Assume self._verify_file_data() was called before, since
+        # we typically have 2 calls to _read_trajectory_data(...); time & data
 
         file_position   = int(self._data_2_info["file_position"])
         sizeof_type     = int(self._data_2_info["sizeof_type"])
@@ -1442,7 +1443,7 @@ class ResultDymolaBinary(ResultDymola):
 
         return data
 
-    def _get_interpolated_trajectory(self, data_index: int, start_index: int = 0, stop_index: int = None) -> Trajectory:
+    def _get_interpolated_trajectory(self, data_index: int, start_index: int = 0, stop_index: int | None = None) -> Trajectory:
         """ Returns an interpolated trajectory for variable of corresponding index 'data_index'. """
         self._verify_file_data()
 
@@ -1455,7 +1456,8 @@ class ResultDymolaBinary(ResultDymola):
         time_vector      = self._read_trajectory_data(0, False, start_index, stop_index)
         data             = self._read_trajectory_data(data_index, False, start_index, stop_index)
 
-        f = scipy.interpolate.interp1d(time_vector, data, fill_value="extrapolate")
+        n = min(len(time_vector), len(data)) # safety for reading wiith allow_file_updates = True
+        f = scipy.interpolate.interp1d(time_vector[:n], data[:n], fill_value = "extrapolate")
 
         # note that we dont need to slice here because diag_time_vector is already sliced accordingly
         self._data_2[data_index] = f(diag_time_vector)


### PR DESCRIPTION
This PR is fixing the issue in 2 different ways; thinking we should have both anyways for extra robustness.

Not sure how to write a good unit test for this, the way to reproduce the issue was:
1.  Start a simulation of a sufficiently large & slow model.
2. In parallel (separate console) run a while loop reading a given (non-diagnostics) trajectory from the growing result file (with `allow_file_updates = True`).
3. Even then, it may take a while to actually hit the right state for the race-condition to become a problem.