### PR TITLE
Fix for retrieving variables with very large value references in CoupledFMUModelME2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@
 --- PyFMI-2.17.2 ---
     * Fixed an issue for dynamic_diagnostics, where failures to evaluate the Jacobian would result in invalid XML.
     * Fixed a race-condition in using ResultDymolaBinary.get_variables_data().
+    * Fixed a bug introduced in PyFMI 2.17.1 that could when retreiving variables with very large value references in CoupledFMUModelME2.
 
 --- PyFMI-2.17.1 ---
     * Fixed compilation issue with Cython 3.1.

--- a/src/pyfmi/fmi_coupled.pyx
+++ b/src/pyfmi/fmi_coupled.pyx
@@ -725,7 +725,7 @@ cdef class CoupledFMUModelBase(CoupledModelBase):
     cdef FMIL2.fmi2_value_reference_t _get_local_vr(self, valueref):
         return valueref & 0x00000000FFFFFFFF
     
-    cdef _get_model_index_from_vr(self, long valueref):
+    cdef _get_model_index_from_vr(self, valueref):
         return valueref >> 32
     
     cdef _get_global_name(self, model_ind, name):


### PR DESCRIPTION
Only observed this issue on Windows.