### PR TITLE
Fixing initial enum values for fmi3

### DIFF
--- a/src/pyfmi/fmil3_import.pxd
+++ b/src/pyfmi/fmil3_import.pxd
@@ -96,10 +96,10 @@ cdef extern from 'fmilib.h':
         fmi3_variability_enu_unknown     = 5
 
     cdef enum fmi3_initial_enu_t:
-        fmi3_initial_enu_exact      = 1,
-        fmi3_initial_enu_approx     = 2,
-        fmi3_initial_enu_calculated = 3,
-        fmi3_initial_enu_unknown    = 4
+        fmi3_initial_enu_exact      = 0,
+        fmi3_initial_enu_approx     = 1,
+        fmi3_initial_enu_calculated = 2,
+        fmi3_initial_enu_unknown    = 3
 
     cdef struct fmi3_xml_variable_t:
         pass


### PR DESCRIPTION
See https://github.com/modelon-community/fmi-library/blob/master/src/Util/include/FMI3/fmi3_enums.h#L120

The Python enums were strangely enough still 0-based, giving the correct result.