### PR TITLE
Co-sim master; support step-size downsampling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,8 +7,7 @@
       * Removed requirement that categories to be set are available via `get_log_categories()`.
     * Added new option `step_size_downsampling_factor` to `Master` algorithm.
       This allows setting reduced input/output update rates on a per-model basis.
-    * `result_downsampling_factor` to `Master` algorithm now  on a per-model basis. 
-      Deprecated used of integer values to this option. 
+    * Enabled use ot `result_downsampling_factor` to `Master` algorithm on a per-model basis. 
 
 --- PyFMI-2.18.3 ---
     * Fixed a bug introduced in PyFMI 2.18.0 causing incorrect result storing for `boolean` and `enum` variables

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
     * Changes to `FMUModelBase2.set_debug_logging()`
       * Now operate on lists of strings instead of bytes.
       * Removed requirement that categories to be set are available via `get_log_categories()`.
+    * Added new option `step_size_downsampling_factor` to `Master` algorithm.
+      This allows setting reduced input/output update rates on a per-model basis.
 
 --- PyFMI-2.18.3 ---
     * Fixed a bug introduced in PyFMI 2.18.0 causing incorrect result storing for `boolean` and `enum` variables

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@
       * Removed requirement that categories to be set are available via `get_log_categories()`.
     * Added new option `step_size_downsampling_factor` to `Master` algorithm.
       This allows setting reduced input/output update rates on a per-model basis.
+    * `result_downsampling_factor` to `Master` algorithm now  on a per-model basis. 
+      Deprecated used of integer values to this option. 
 
 --- PyFMI-2.18.3 ---
     * Fixed a bug introduced in PyFMI 2.18.0 causing incorrect result storing for `boolean` and `enum` variables

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,7 @@
       * Removed requirement that categories to be set are available via `get_log_categories()`.
     * Added new option `step_size_downsampling_factor` to `Master` algorithm.
       This allows setting reduced input/output update rates on a per-model basis.
-    * Enabled use ot `result_downsampling_factor` to `Master` algorithm on a per-model basis. 
+    * Enabled use of `result_downsampling_factor` to `Master` algorithm on a per-model basis. 
 
 --- PyFMI-2.18.3 ---
     * Fixed a bug introduced in PyFMI 2.18.0 causing incorrect result storing for `boolean` and `enum` variables

--- a/src/common/algorithm_drivers.py
+++ b/src/common/algorithm_drivers.py
@@ -345,7 +345,12 @@ class OptionBase(dict):
                 if not key in self._keys:
                     raise UnrecognizedOptionError(
                         "The key: %s, is not a valid option" %str(key))
+                # default value is a dictionary
                 if isinstance(self[key], dict):
+                    # check input is also a dictionary
+                    if not isinstance(other[key], dict):
+                        raise UnrecognizedOptionError(
+                            "The options in '%s' needs to be provided as a dictionary." %str(key))
                     self[key].update(other[key])
                 else:
                     self[key] = other[key]

--- a/src/pyfmi/master.pyx
+++ b/src/pyfmi/master.pyx
@@ -554,7 +554,7 @@ cdef class Master:
         
     def report_solution(self, double cur_time, bool store_step_before_update = False):
         models_to_store_solution = None
-        if store_step_before_update: # takes precende of last_step storing
+        if store_step_before_update: # takes precedence over last_step storing
             # only store those steps that will be updated
             models_to_store_solution = {m: v for m, v in self.models_dict.items() if \
                 (

--- a/src/pyfmi/master.pyx
+++ b/src/pyfmi/master.pyx
@@ -336,8 +336,8 @@ class MasterAlgOptions(OptionBase):
             Default: False
 
         result_downsampling_factor --
-            Dictionary {model: int > 0}.
-            A given model only stores every
+            int > 0 or dictionary {model: int > 0}.
+            A given model (all, if int value) only stores every
             <result_downsampling_factor>-th communication point.
             Start & end point are always included.
             Affects results storing from the 'store_step_before_update' option.
@@ -403,12 +403,6 @@ class MasterAlgOptions(OptionBase):
     def __setitem__(self, key, value):
         # OptionBase enforce same type (e.g., int, dict) for inputs; exceptions to this format here
         if key == "result_downsampling_factor" and not isinstance(value, dict):
-            warnings.warn(
-                "Use of simple value inputs for 'result_downsampling_factor' is deprecated, " \
-                "use a dictionary with models as keys instead.",
-                DeprecationWarning,
-                stacklevel=2
-            )
             # non-dict inputs are applied on all models
             factor_dict = {model: value for model in self.__getitem__("result_downsampling_factor").keys()}
             super().__setitem__(key, factor_dict)

--- a/src/pyfmi/master.pyx
+++ b/src/pyfmi/master.pyx
@@ -650,7 +650,7 @@ cdef class Master:
         cdef int i, nlocal, status
 
         for model in self.models_dict.keys():
-            # Note: _downsampling_skip if supporting step_size_downsampling_factor + linear_correction || extrapolation_order > 0
+            # Note: Will require _downsampling_skip if supporting step_size_downsampling_factor + linear_correction || extrapolation_order > 0
             nlocal = self.models_dict[model]["local_input_len"]
             #v = [0.0]*nlocal
             for i in range(nlocal):
@@ -696,7 +696,7 @@ cdef class Master:
         cdef list col = []
 
         for model in self.models_dict.keys():
-            # Note: _downsampling_skip if supporting step_size_downsampling_factor + linear_correction || extrapolation_order > 0
+            # Note: Will require _downsampling_skip if supporting step_size_downsampling_factor + linear_correction || extrapolation_order > 0
             if model.get_generation_tool() != "JModelica.org":
                 return None
             v = [0.0]*len(self.models_dict[model]["local_state_vref"])
@@ -713,7 +713,7 @@ cdef class Master:
         cdef list col = []
 
         for model in self.models_dict.keys():
-            # Note: _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 1
+            # Note: Will require _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 1
             if model.get_generation_tool() != "JModelica.org":
                 return None
             v = [0.0]*len(self.models_dict[model]["local_state_vref"])
@@ -730,7 +730,7 @@ cdef class Master:
         cdef list col = []
 
         for model in self.models_dict.keys():
-            # Note: _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 1
+            # Note: Will require _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 1
             if model.get_generation_tool() != "JModelica.org":
                 return None
             v = [0.0]*len(self.models_dict[model]["local_input_vref"])
@@ -869,7 +869,7 @@ cdef class Master:
                 return None
 
         for model in self.models:
-            # Note: _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 0
+            # Note: Will require _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 0
             index_start = self.models_dict[model]["global_index_derivatives"]
             index_end = index_start + self.models_dict[model]["local_derivative_len"]
             local_derivative_vref_array = (<FMI2.FMUModelCS2>model).get_real(self.models_dict[model]["local_derivative_vref_array"])
@@ -903,7 +903,7 @@ cdef class Master:
         if self.opts["extrapolation_order"] > 0:
             if self.max_output_derivative_order > 0 and not self.opts["force_finite_difference_outputs"]:
                 for model in self.models_dict.keys():
-                    # Note: _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 0
+                    # Note: Will require _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 0
                     i = self.models_dict[model]["global_index_outputs"]
                     inext = i + self.models_dict[model]["local_output_len"]
                     status = (<FMI2.FMUModelCS2>model)._get_output_derivatives(self.models_dict[model]["local_output_vref_array"], ydtmp, self.models_dict[model]["local_output_vref_ones"])
@@ -951,7 +951,7 @@ cdef class Master:
         if self.opts["extrapolation_order"] > 1:
             if self.max_output_derivative_order > 1 and not self.opts["force_finite_difference_outputs"]:
                 for model in self.models_dict.keys():
-                    # Note: _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 1
+                    # Note: Will require _downsampling_skip if supporting step_size_downsampling_factor + extrapolation_order > 1
                     i = self.models_dict[model]["global_index_outputs"]
                     inext = i + self.models_dict[model]["local_output_len"]
                     status = (<FMI2.FMUModelCS2>model)._get_output_derivatives(self.models_dict[model]["local_output_vref_array"], yddtmp, self.models_dict[model]["local_output_vref_twos"])

--- a/src/pyfmi/master.pyx
+++ b/src/pyfmi/master.pyx
@@ -348,9 +348,9 @@ class MasterAlgOptions(OptionBase):
 
         step_size_downsampling_factor -- 
             Dictionary {model: int > 0}. 
-            A given model only updates updates its in&outputs every
+            A given model only updates its inputs and outputs every
             <step_size_downsampling_factor>-th communication point.
-            Usage the following options values is not supported:
+            The following options values is not supported together with the step-size downsampling option:
                 'error_controlled' = True
                 'linear_correction' = True
                 'extrapolation_order' > 0

--- a/src/pyfmi/master.pyx
+++ b/src/pyfmi/master.pyx
@@ -350,7 +350,8 @@ class MasterAlgOptions(OptionBase):
             Dictionary {model: int > 0}. 
             A given model only updates its inputs and outputs every
             <step_size_downsampling_factor>-th communication point.
-            The following options values is not supported together with the step-size downsampling option:
+            The following options values are not supported together with 
+            the step_size_downsampling_factor option:
                 'error_controlled' = True
                 'linear_correction' = True
                 'extrapolation_order' > 0
@@ -390,7 +391,8 @@ class MasterAlgOptions(OptionBase):
         "step_size_downsampling_factor" : dict((model, 1) for model in master.models),
         }
         super(MasterAlgOptions,self).__init__(_defaults)
-        # Can be removed once we removed separate treatment of result_downsampling_factor
+        # Exceptions to the above types need to handled here, e.g., allowing both
+        # int & dict values for a given option
         result_downsampling_factor = None
         for a in args:
             if "result_downsampling_factor" in a:

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -19,10 +19,13 @@
 # Also shortlist for any candidates to be removed
 
 import pytest
+import re
 from pathlib import Path
 
 from pyfmi import load_fmu
 from pyfmi.common.io import ResultStorage
+from pyfmi.master import Master
+from pyfmi.fmi2 import FMUModelCS2
 
 this_dir = Path(__file__).parent.absolute()
 FMI2_REF_FMU_PATH = Path(this_dir) / 'files' / 'reference_fmus' / '2.0'
@@ -47,3 +50,15 @@ def test_result_handler_name_attribute(result_handling):
     msg = "Use the `get_variable_names` function instead."
     with pytest.warns(DeprecationWarning, match = msg):
         res.result_data.name
+
+def test_master_alg_downsample_result_simple_value():
+    """Test setting a simple value to the 'result_downsampling_factor' option for the Master algorithm."""
+    fmu1 = FMUModelCS2(FMI2_REF_FMU_PATH / "Feedthrough.fmu")
+    fmu2 = FMUModelCS2(FMI2_REF_FMU_PATH / "Feedthrough.fmu")
+
+    models = [fmu1, fmu2]
+    connections = [(fmu1, "Float64_continuous_output", fmu2, "Float64_continuous_input")]
+    master = Master(models, connections)
+    msg = "Use of simple value inputs for 'result_downsampling_factor' is deprecated, use a dictionary with models as keys instead."
+    with pytest.warns(DeprecationWarning, match = re.escape(msg)):
+        master.simulate(0, 1, options = {"step_size": 0.5, "result_downsampling_factor": 2})

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -50,15 +50,3 @@ def test_result_handler_name_attribute(result_handling):
     msg = "Use the `get_variable_names` function instead."
     with pytest.warns(DeprecationWarning, match = msg):
         res.result_data.name
-
-def test_master_alg_downsample_result_simple_value():
-    """Test setting a simple value to the 'result_downsampling_factor' option for the Master algorithm."""
-    fmu1 = FMUModelCS2(FMI2_REF_FMU_PATH / "Feedthrough.fmu")
-    fmu2 = FMUModelCS2(FMI2_REF_FMU_PATH / "Feedthrough.fmu")
-
-    models = [fmu1, fmu2]
-    connections = [(fmu1, "Float64_continuous_output", fmu2, "Float64_continuous_input")]
-    master = Master(models, connections)
-    msg = "Use of simple value inputs for 'result_downsampling_factor' is deprecated, use a dictionary with models as keys instead."
-    with pytest.warns(DeprecationWarning, match = re.escape(msg)):
-        master.simulate(0, 1, options = {"step_size": 0.5, "result_downsampling_factor": 2})

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -19,13 +19,10 @@
 # Also shortlist for any candidates to be removed
 
 import pytest
-import re
 from pathlib import Path
 
 from pyfmi import load_fmu
 from pyfmi.common.io import ResultStorage
-from pyfmi.master import Master
-from pyfmi.fmi2 import FMUModelCS2
 
 this_dir = Path(__file__).parent.absolute()
 FMI2_REF_FMU_PATH = Path(this_dir) / 'files' / 'reference_fmus' / '2.0'

--- a/tests/test_fmi_master.py
+++ b/tests/test_fmi_master.py
@@ -491,6 +491,13 @@ class Test_Master_Result_Downsampling:
         np.testing.assert_array_equal(res[self.fmu1]["Float64_continuous_output"], expected_res)
         np.testing.assert_array_equal(res[self.fmu2]["Float64_continuous_output"], expected_res)
 
+    def test_master_alg_downsample_result_simple_value(self):
+        """Test setting a simple value to the 'result_downsampling_factor' option for the Master algorithm."""
+        res = self._sim_basic_simulation({'result_downsampling_factor': 2}, final_time = 10)
+        expected_res = [0, 2, 4, 6, 8, 10]
+        np.testing.assert_array_equal(res[self.fmu1]["Float64_continuous_output"], expected_res)
+        np.testing.assert_array_equal(res[self.fmu2]["Float64_continuous_output"], expected_res)
+
     @pytest.mark.parametrize("factor, expected_res",
         [
             (1, [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10]), # sanity


### PR DESCRIPTION
Could optionally also add some interaction between `result_downsampling_factor` and `step_size_downsampling_factor`, e.g., 

1. `result_downsampling_factor` default values given by `step_size_downsampling_factor`
2. Enforce (or warn if not) `result_downsampling_factor[model]` be an integer multiple of `step_size_downsampling_factor[model]`.